### PR TITLE
add dynamic versioning

### DIFF
--- a/lua/sql.lua
+++ b/lua/sql.lua
@@ -12,6 +12,8 @@ local booleansql = function(value) -- TODO: should be done a clib level
   return value
 end
 
+sql.version = "0.1"
+
 --- Internal function for creating new connection.
 ---@todo: decide whether using os.time and epoch time would be better.
 -- sets {created, conn, closed}


### PR DESCRIPTION
Users of plugins that uses `sql.nvim` may encounter issues due to a possibly out-date version or unsupported version of `sql.nvim`. 

Thus, this pr aims to help plugin developers by either  
- enabling them to add safe gurds that match what version they support with the value of `sql.version`, or 
- letting them inquire for the output of `print(require'sql'.version)` from their users.

TODOS: 
- [ ] find a way to set sql.version using github actions

If `doc/version.txt` exists then the version should content of `version.txt + git commit hash`