### PR TITLE
Add sql:table object and methods

### DIFF
--- a/lua/sql/table.lua
+++ b/lua/sql/table.lua
@@ -1,0 +1,251 @@
+local u = require'sql.utils'
+local t = {}
+t.__index = t
+
+function t:__run(func)
+  if self.db.closed then
+    return self.db:with_open(function()
+      return func() -- shoud pass tbl name?
+    end)
+  else
+   return func()
+  end
+end
+
+local get_key = function(query)
+  local items = {}
+  for k, v in u.opairs(query) do
+    table.insert(items, string.format("%s=%s", k, table.concat((function()
+      if not u.is_list(v) then
+        local tmp = {}
+        for _k,_v in u.opairs(v) do
+          if type(_v) == "table" then
+            table.insert(tmp, string.format("%s=%s", _k, table.concat(_v, ",")))
+            else
+          table.insert(tmp, string.format("%s=%s", _k, _v))
+          end
+        end
+        return tmp
+      else
+        return v
+      end
+    end)(), "")))
+  end
+
+  return table.concat(items, ",")
+end
+
+
+function t:__clear_cache(succ, change)
+  -- TODO: maybe do something smart here to update cache :D
+  if succ then
+    self.cache = {}
+    self.db.modified = false
+  end
+end
+
+function t:__fill_cache(query, res)
+  self.cache[get_key(query)] = res
+end
+
+function t:__get_from_cache(query)
+  if self.db.modified or vim.loop.fs_stat(self.db.uri).mtime.sec ~= self.mtime then
+    self.__clear_cache(true, nil)
+    self.db.modified = false
+    return nil
+  end
+  return self.cache[get_key(query)]
+end
+
+
+function t:new(db, tbl)
+  local o = {}
+  o.cache = {}
+  o.db = db
+  o.tbl = tbl
+  o.mtime = vim.loop.fs_stat(o.db.uri).mtime.sec -- db:close/open changes this value, not sql:change commands
+
+  setmetatable(o, self)
+
+  o:__run(function()
+    o.tbl_exists = o.db:exists(o.tbl)
+    o.has_content = o.tbl_exists and o:count() ~= 0 or false
+  end)
+  return o
+end
+
+--- Create or change {self.tbl} schema. If no {schema} is given,
+--- then it return current the used schema.
+---@param schema table: table schema definition
+---@return table: list of keys or keys and their type.
+function t:schema(schema)
+  local res
+  return self:__run(function()
+    if not schema then -- TODO: or table is empty
+      return self.tbl_exists and self.db:schema(self.tbl) or {}
+    elseif not self.tbl_exists or schema.ensure then
+      res = self.db:create(self.tbl, schema)
+      self.tbl_exists = res
+      return res
+    else -- maybe better to use alter
+      res = self.db:drop(self.tbl)
+      res = res and self.db:create(self.tbl, schema) or false
+      return res
+    end
+  end)
+end
+
+--- Same functionalities as |sql:drop()|, if the table is already drooped
+--- then it returns false
+---@return boolean
+function t:drop()
+  if not self.tbl_exists then return false end
+  return self:__run(function()
+    local res = self.db:drop(self.tbl)
+    if res then self.tbl_exists = false end
+    return res
+  end)
+end
+
+
+--- Predicate that returns true if the table is empty
+---@return boolean
+function t:empty() return not self.has_content end
+
+--- Predicate that returns true if the table exists
+---@return boolean
+function t:exists() return self.tbl_exists end
+
+--- The count of the rows in {self.tbl}.
+---@return number: number of rows in {self.tbl}
+function t:count()
+  if not self.tbl_exists then return end
+  return self:__run(function()
+    local res = self.db:eval("select count(*) from " .. self.tbl)
+    return res[1]["count(*)"]
+  end)
+end
+
+
+--- Query the table and return results. If the {query} has been ran before, then
+--- query results from cache will be returned.
+---@param query table: query.where, query.keys, query.join
+---@return table: empty table if no result
+---@see sql:select()
+function t:get(query)
+  query = query or { query = {all = 1} }
+  local cache = self:__get_from_cache(query)
+  if cache then return cache end
+
+  return self:__run(function()
+    local res = self.db:select(self.tbl, query)
+    if res then self:__fill_cache(query, res) end
+    return res
+  end)
+end
+
+--- Iterate over {self.tbl} rows and execute {func}.
+---@param query table: query.where, query.keys, query.join
+---@param func function: a function that expects a row
+---@return boolean: true if rows ~= empty table
+function t:each(query, func)
+  assert(type(func) == "function", "required a function as second params")
+  local cache = self:__get_from_cache(query)
+  local rows = cache and cache or (function()
+    local res = self.db:select(self.tbl, query)
+    if res then self:__fill_cache(query, res) end
+    return res
+  end)()
+  if not rows then return end
+  for _, row in ipairs(rows) do
+    func(row)
+  end
+  return rows ~= {} or type(rows) ~= "boolean"
+end
+
+--- create a new table from iterating over {self.tbl} rows with {func}.
+---@param query table: query.where, query.keys, query.join
+---@param func function: a function that expects a row
+---@return boolean: true if rows ~= empty table
+function t:map(query, func)
+  assert(type(func) == "function", "required a function as second params")
+  local res = {}
+  self:each(query, function(row)
+      table.insert(res, func(row))
+  end)
+  return res
+end
+
+--- Sorts a table in-place using a transform. Values are ranked in a custom order of the results of
+--- running `transform (v)` on all values. `transform` may also be a string name property  sort by.
+--- `comp` is a comparison function. Adopted from Moses.lua
+---@param query table: query.where, query.keys, query.join
+---@param transform function or string: a `transform` function to sort elements. Defaults to @{identity}
+---@param comp function: a comparison function, defaults to the `<` operator
+---@return table: list of sorted values
+function t:sort(query, transform, comp)
+  local res = self:get(query)
+  local f = transform or function(r) return r[u.keys(query.where)[1]] end
+  if (type(transform) == 'string') then
+    f = function(r) return r[transform] end
+  end
+  comp = comp or function(a,b) return a < b end
+  table.sort(res, function(a,b) return comp(f(a), f(b)) end)
+  return res
+end
+
+--- Same functionalities as |sql:insert()|
+---@param rows table: a row or a group of rows
+---@see t:__run()
+---@see sql:insert()
+---@return boolean
+function t:insert(rows)
+  return self:__run(function()
+    local succ = self.db:insert(self.tbl, rows)
+    self:__clear_cache(succ, rows)
+    return succ
+  end)
+end
+
+--- Same functionalities as |sql:delete()|
+---@param specs table: specs.where
+---@see t:__run()
+---@see sql:delete()
+---@return boolean
+function t:remove(specs)
+  return self:__run(function()
+    local succ = self.db:delete(self.tbl, specs)
+    self:__clear_cache(succ, specs)
+    return succ
+  end)
+end
+
+--- Same functionalities as |sql:update()|
+---@param specs table: a table or a list of tables with where and values keys.
+---@see t:__run()
+---@see sql:update()
+---@return boolean
+function t:update(specs)
+  return self:__run(function()
+    local succ = self.db:update(self.tbl, specs)
+    self:__clear_cache(succ, specs)
+    return succ
+  end)
+end
+
+--- Same functionalities as |t:add()|, but replaces {self.tbl} content with {rows}
+---@param rows table: a row or a group of rows
+---@see t:__run()
+---@see sql:delete()
+---@see sql:insert()
+---@return boolean
+function t:replace(rows)
+  return self:__run(function()
+    self.db:delete(self.tbl)
+    local succ = self.db:insert(self.tbl, rows)
+    self:__clear_cache(succ, rows)
+    return succ
+  end)
+end
+
+return t

--- a/lua/sql/utils.lua
+++ b/lua/sql/utils.lua
@@ -171,4 +171,27 @@ M.flatten = function(tbl)
   return result
 end
 
+-- taken from: https://github.com/neovim/neovim/blob/master/runtime/lua/vim/shared.lua
+M.is_list = function(t)
+  if type(t) ~= 'table' then
+    return false
+  end
+
+  local count = 0
+
+  for k, _ in pairs(t) do
+    if type(k) == "number" then
+      count = count + 1
+    else
+      return false
+    end
+  end
+
+  if count > 0 then
+    return true
+  else
+    return getmetatable(t) ~= {}
+  end
+end
+
 return M

--- a/test/auto/table_spec.lua
+++ b/test/auto/table_spec.lua
@@ -1,0 +1,333 @@
+local sql = require'sql'
+local eq = assert.are.same
+local demo = {
+  { a = 1,  b = "lsf", c = "de" },
+  { a = 99, b = "sdj", c = "in" },
+  { a = 32, b = "sbs", c = "en" },
+  { a = 12, b = "srd", c = "fn" },
+  { a = 35, b = "cba", c = "qa" },
+  { a = 4,  b = "pef", c = "ru" },
+  { a = 5,  b = "sam", c = "da" },
+}
+
+local dbpath = "/tmp/tbl_methods_test.sql"
+vim.loop.fs_unlink(dbpath)
+local db = sql.new(dbpath, true)
+
+local seed = function()
+  db:open()
+  db:create("T", { a = "integer", b = "text", c = "text", ensure = true})
+  db:insert("T", demo)
+  return db:table("T"), db:table("N")
+end
+
+local clean = function()
+  db:close()
+  vim.loop.fs_unlink(dbpath)
+end
+
+describe('table', function()
+  local t1, t2 = seed()
+
+  describe(':new', function()
+    it('create new object with sql.table methods.', function()
+      eq("table", type(t1))
+    end)
+    it('registers table name in self.tbl.', function()
+      eq("T", t1.tbl)
+    end)
+    it('registers whether the table exists in self.tbl_exists.', function()
+      eq(true, t1.tbl_exists)
+    end)
+    it('registers whether the table has content in self.has_content.', function()
+      eq(true, t1.has_content, 'should be false')
+    end)
+    it('initalizes empty cache in self.cache', function()
+      eq({}, t1.cache, 'should be empty.')
+    end)
+    it("doesn't fail if table isn't created yat.", function()
+      eq("table", type(t2))
+    end)
+  end)
+
+  describe(':schema', function()
+    it('returns schema if self.tbl exists', function()
+      eq({ a = "integer", b = "text", c = "text" }, t1:schema())
+    end)
+    it("returns empty table if schema doesn't exists", function()
+      eq({}, t2:schema())
+    end)
+    it("creates new table with schema", function()
+      local schema = { id = "int", a = "text", d = "text" }
+      eq(true, t2:schema(schema), "Should return true")
+      eq(schema, t2:schema(), "should return the schema.")
+      eq(true, t2.tbl_exists, "should alter self.exists value")
+    end)
+    it("should drop and recreate the table if not schema.ensure", function()
+      local new = { id = "int", a = "text", f = "text" }
+      eq(true, t2:schema(new), "Should return true")
+      eq(new, t2:schema(), "should return the schema.")
+      eq(true, t2.tbl_exists, "should alter self.exists value")
+    end)
+    it("should skip looking at the schema if schema.ensure", function()
+      local old = t2:schema()
+      local new = { i = "int", aaa = "text", fff = "text", ensure = true }
+      eq(true, t2:schema(new), "Should return true")
+      eq(old, t2:schema(), "should return the schema.")
+    end)
+  end)
+
+  describe(":drop/:exists", function()
+    it("should drop table", function()
+      eq(true, t2:drop(), "should return true")
+      eq(false, t2:exists(), "should not exists.")
+    end)
+    it("should return false if already dropped", function()
+      eq(false, t2:drop(), "should be false")
+    end)
+  end)
+
+  describe(":get", function()
+    it("return everything.", function()
+      local res = t1:get()
+      eq(demo, res, "should be identical")
+    end)
+
+    it("runs a query and returns results (where)", function()
+      local res = t1:get{ where = {a = 1} }
+      eq(demo[1], res[1], "should be identical")
+    end)
+
+    it("runs a query and returns results (where & keys)", function()
+      local res = t1:get{ keys = { "b", "c" }, where = { a = 1 } }
+      demo[1].a = nil
+      eq(demo[1], res[1], "should be identical")
+      demo[1].a = 1
+    end)
+
+    it("runs a query from cache.", function()
+      local res = t1:get{ keys = { "b", "c" }, where = { a = 1 } }
+      t1.cache["keys=bc,select=bc,where=a=1"][1].b = "bddddd"
+      demo[1].b = "bddddd"
+      demo[1].a = nil
+      eq(demo[1], res[1], "should be identical")
+      demo[1].b = "lsf"
+      demo[1].a = 1
+    end)
+
+    it("cache should be cleared.", function()
+      eq(vim.loop.fs_stat(dbpath).mtime.sec, t1.mtime, "should be the same")
+      eq(true, db:eval("insert into T(a,b,c) values(?,?,?)", {200, "a", "f"}), "should insert")
+      eq(true, t1.db.modified, "should be modified tr")
+      assert(not t1:__get_from_cache(), "cache should be nil.")
+      eq(false, t1.db.modified, "should not be modified after this function is ran.")
+      assert(db:eval("delete from T where a = 200"), "should be deleted")
+    end)
+
+    it("run a query and returns results when connection is closed.", function()
+      db:close()
+      local res = t1:get{ where = { a = 99 } }
+      eq(demo[2], res[1], "should be identical")
+    end)
+
+    it("the db should stay closed after doing the query.", function()
+      eq(true, t1.db.closed, "should update the state")
+      eq(true, db.closed, "should update the state")
+      db:open()
+    end)
+  end)
+
+  describe(":each", function()
+    it("should work func", function()
+      local res = {}
+      eq(true, t1:each({where = {a = {12,99,32}}}, function(row)
+        table.insert(res, row.a)
+      end), "the number of rows")
+      eq(res, {99,32,12}, "should be identical") -- this might fail at some point because of the ordering.
+    end)
+
+    it("should return from cache.", function()
+      t1:get{where = {a = {12,99,32}}}
+      local res = {}
+      t1.cache["where=a=12,99,32"][1].a = 1
+      t1.cache["where=a=12,99,32"][2].a = 2
+      t1.cache["where=a=12,99,32"][3].a = 3
+
+      t1:each({where = {a = {12,99,32}}}, function(row)
+        table.insert(res, row.a)
+      end)
+
+      eq(res, {1,2,3}, "should be identical") -- this might fail at some point because of the ordering.
+    end)
+  end)
+
+
+  t1.cache = {}
+
+  describe(":map", function()
+    it("should work func", function()
+      local res = t1:map({where = {a = {12,99,32}}}, function(row)
+        return row.a
+      end)
+      eq(res, {99,32,12}, "should be identical") -- this might fail at some point because of the ordering.
+    end)
+
+    it("should return from cache.", function()
+      t1:get{where = {a = {12,99,32}}}
+      t1.cache["where=a=12,99,32"][1].a = 1
+      t1.cache["where=a=12,99,32"][2].a = 2
+      t1.cache["where=a=12,99,32"][3].a = 3
+
+      local res = t1:map({where = {a = {12,99,32}}}, function(row)
+        return row.a
+      end)
+
+      eq(res, {1,2,3}, "should be identical") -- this might fail at some point because of the ordering.
+    end)
+  end)
+
+  describe(':sort', function()
+
+    it('transform function defaults to to first where key', function()
+      eq({
+        { a = 4,  b = "pef", c = "ru" },
+        { a = 5,  b = "sam", c = "da" },
+        { a = 35, b = "cba", c = "qa" },
+      }, t1:sort({where = {a = {35, 4, 5}}}), "should be identical")
+    end)
+
+    it('transform function can be a string with row key ', function()
+      eq({
+        { a = 12, b = "srd", c = "fn" },
+        { a = 32, b = "sbs", c = "en" },
+        { a = 35, b = "cba", c = "qa" },
+      }, t1:sort({where = {a = {32,12,35}}}, "a"))
+      eq({
+        { a = 32, b = "sbs", c = "en" },
+        { a = 12, b = "srd", c = "fn" },
+        { a = 35, b = "cba", c = "qa" },
+      }, t1:sort({where = {a = {32,12,35}}}, "c"))
+      eq({
+        { a = 35, b = "cba", c = "qa" },
+        { a = 32, b = "sbs", c = "en" },
+        { a = 12, b = "srd", c = "fn" },
+      }, t1:sort({where = {a = {32,12,35}}}, "b"))
+    end)
+
+    it('can use a custom comparison function', function()
+      local comp = function(a, b) return a > b end
+      eq({
+        { a = 12, b = "srd", c = "fn" },
+        { a = 32, b = "sbs", c = "en" },
+        { a = 35, b = "cba", c = "qa" },
+      }, t1:sort({where = {a = { 32,12,35 }}}, "b", comp))
+    end)
+
+  end)
+
+  describe(":remove", function()
+    it("pre ... fill cache", function()
+      eq({demo[3]}, t1:get{ where = {a = 32} }, "should be identical.")
+      eq({demo[4]}, t1:get{ where = {a = 12} }, "should be identical.")
+      eq("table", type(t1.cache["where=a=32"][1]), "should be filled")
+    end)
+
+    it("removes a single row", function()
+      eq(true, t1:remove{ where = { a = 5 } }, "should remove")
+      eq(true, db:eval("select * from T where a = 5"), "should return boolean, if no resluts")
+    end)
+
+    it("removes a multiple rows", function()
+      eq(true, t1:remove{ where = { a = {35,4} } }, "should remove")
+      eq(true, db:eval("select * from T where a = 35 or a = 4"), "should return boolean, if no resluts")
+    end)
+
+    it("should empty cache", function()
+      eq({}, t1.cache, "should remove")
+    end)
+  end)
+
+  clean()
+  seed()
+
+  describe(":update", function()
+    it("pre ... fill cache", function()
+      eq({demo[3]}, t1:get{ where = {a = 32} }, "should be identical.")
+      eq({demo[4]}, t1:get{ where = {a = 12} }, "should be identical.")
+      eq("table", type(t1.cache["where=a=32"][1]), "should be filled")
+    end)
+
+    it("update a single row", function()
+      eq(true, t1:update{ where = { a = 4 }, values = { c = "a", b = "a"} }, "should be updated")
+      demo[6] = { a = 4, c = "a", b = "a" }
+      eq({demo[6]}, db:eval("select * from T where a = 4"), "should return boolean, if no resluts")
+    end)
+
+    it("update a multiple rows", function()
+      eq(true, t1:update{
+        {
+          where = { a = 35 }, values = { c = "a", b = "a"}
+        },
+        {
+          where = { a = 5 }, values = { c = "a", b = "a"}
+        },
+
+      }, "should be updated")
+      demo[7] = { a = 5, c = "a", b = "a" }
+      demo[5] = { a = 35, c = "a", b = "a" }
+      eq({demo[7]}, db:eval("select * from T where a = 5"), "should return boolean, if no resluts")
+      eq({demo[5]}, db:eval("select * from T where a = 35"), "should return boolean, if no resluts")
+    end)
+
+    it("should empty cache", function()
+      eq({}, t1.cache, "should remove")
+    end)
+  end)
+
+  clean()
+  seed()
+
+  describe(":replace", function()
+    it("replcaes table content with new content", function()
+      local new_rows = {
+        { a = 1,  b = "lsf", c = "de" },
+        { a = 2, b = "sdj", c = "in" },
+        { a = 3, b = "sbs", c = "en" }
+      }
+      eq(true, t1:replace(new_rows), "it should return true")
+      eq(new_rows, t1:get(), "it should have the new rows")
+    end)
+  end)
+
+  clean()
+  seed()
+
+  describe(":insert", function()
+    it("inserts a row", function()
+      local new_rows = { a = 109,  b = "0", c = "0" }
+      eq(true, t1:insert(new_rows), "it should return true")
+      eq({new_rows}, db:eval("select * from T where a = 109"), "it should have the new rows")
+    end)
+
+    it("inserts a list of rows", function()
+      local new_rows = {
+        { a = 11,  b = "lsf", c = "de" },
+        { a = 22, b = "sdj", c = "in" },
+        { a = 33, b = "sbs", c = "en" }
+      }
+      eq(true, t1:insert(new_rows), "it should return true")
+      eq(new_rows, db:eval("select * from T where a = 11 or a = 22 or a = 33"), "it should have the new rows")
+    end)
+  end)
+
+  clean()
+  seed()
+
+  describe(":count", function()
+    it("retunrs the current number of rows in a db", function()
+      eq(7, t1:count(), "the number of rows")
+    end)
+  end)
+
+  clean()
+end)


### PR DESCRIPTION
closes #18

### Changes in sql.lua 

- modified error message 
- added few todos.
- added new property to internally keep track of db status.
- change return value of sql:schema to return empty table if no schema.
- added table

### New methods to sql/table.lua 

- new
- schema
- exists
- empty
- drop
- count
- get
- sort
- each
- map
- insert
- remove
- replace
- update

