### PR TITLE
Add installation instructions for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ Ensure you have `sqlite3` and `libsqlite3-dev` installed
 sudo apt-get install sqlite3 libsqlite3-dev
 ```
 
+#### Arch 
+Coming soon.
+
+#### MacOS
+Coming soon.
+
+#### Windows 
+Coming soon.
+
 
 Usage
 -----------------

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ welcomed. Issues, feature and suggestions are encouraged.
 Installation
 -----------------
 
+#### Neovim
+
 To install or take advantage of sql.nvim correctly, simply add sql.nvim to
 your lua `package.path`, neovim `/**/start/` or use your favorite
 vim package manager.
@@ -45,8 +47,10 @@ that you set `g:sql_clib_path` or `vim.g.sql_clib_path` to where
 `libsqlite3.so` is located, and if that the case, pr or issue are welcomed to
 add to sql.nvim lookup paths for `libsqlite3.so`.
 
-If installing this plugin on `ubuntu` you might need to install `libsqlite3-dev`, in order for
+#### Ubuntu
+You might need to install `libsqlite3-dev`, in order for
 this package to work
+
 
 Usage
 -----------------

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ that you set `g:sql_clib_path` or `vim.g.sql_clib_path` to where
 `libsqlite3.so` is located, and if that the case, pr or issue are welcomed to
 add to sql.nvim lookup paths for `libsqlite3.so`.
 
+If installing this plugin on `ubuntu` you might need to install `libsqlite3-dev`, in order for
+this package to work
+
 Usage
 -----------------
 For more usage example, please review test/auto/ and docs/sql.txt.

--- a/README.md
+++ b/README.md
@@ -48,8 +48,11 @@ that you set `g:sql_clib_path` or `vim.g.sql_clib_path` to where
 add to sql.nvim lookup paths for `libsqlite3.so`.
 
 #### Ubuntu
-You might need to install `libsqlite3-dev`, in order for
-this package to work
+Ensure you have `sqlite3` and `libsqlite3-dev` installed
+
+```
+sudo apt-get install sqlite3 libsqlite3-dev
+```
 
 
 Usage


### PR DESCRIPTION
`libsqlite3-dev` is a required dependency when installing on Ubuntu (or at least I found it to be running Ubuntu 20.10). Not sure if this applies to other Linux distros, so I've made the instruction specific to ubuntu but could be a useful flag for linux users that they might need to make sure some packages are available.

Lemme know if you'd rather reword this or display it differently/not at all.