### PR TITLE
Add Apple silicon support

### DIFF
--- a/lua/sql/defs.lua
+++ b/lua/sql/defs.lua
@@ -5,7 +5,11 @@ local M = {}
 
 local clib_path = vim.g.sql_clib_path or (function()
   if vim.loop.os_uname().sysname == 'Darwin' then
-    return '/usr/local/opt/sqlite3/lib/libsqlite3.dylib'
+	if vim.loop.os_uname().machine == "arm64" then
+		return "/opt/homebrew/opt/sqlite/lib/libsqlite3.dylib"
+	else
+		return "/usr/local/opt/sqlite3/lib/libsqlite3.dylib"
+	end
   end
   return 'libsqlite3'
 end)()


### PR DESCRIPTION
Loads `libsqlite3.dylib` from `/opt/homebrew/opt/sqlite/lib/libsqlite3.dylib` when running on arm.