### PR TITLE
fix: Not null field primary key is not "required"

### DIFF
--- a/lua/sql.lua
+++ b/lua/sql.lua
@@ -255,12 +255,12 @@ function sql:schema(tbl, info)
   local types = {}
 
   for _, v in ipairs(sch) do
-    if v.notnull == 1 then req[v.name] = v end
+    if v.notnull == 1 and v.pk == 0 then req[v.name] = v end
     if v.dflt_value then def[v.name] = v.dflt_value end
 
     tbl_info[v.name] = {
       required = v.notnull == 1,
-      primary = v.ok == 1,
+      primary = v.pk == 1,
       type = v.type,
       cid = v.cid,
       default = v.dflt_value


### PR DESCRIPTION
This is a partial fix to #46 now is not required to provide the primary key to perform an insert. 

Also fixed a typo.

Since the field value is auto-incremented by sqlite if not provided.
https://www.sqlite.org/autoinc.html
https://www.sqlite.org/c3ref/last_insert_rowid.html