### PR TITLE
Insert last inserted row id.

### DIFF
--- a/lua/sql.lua
+++ b/lua/sql.lua
@@ -342,10 +342,7 @@ function sql:insert(tbl, rows)
       s:bind_clear()
       table.insert(ret_vals, s:finalize())
     end
-      local s = self:__parse("SELECT last_insert_rowid()")
-      s:step()
-      last_rowid = s:vals()[1]
-      s:finalize()
+      last_rowid = tonumber(clib.last_insert_rowid(self.conn))
   end)
 
   local succ = u.all(ret_vals, function(_, v) return v end)

--- a/lua/sql.lua
+++ b/lua/sql.lua
@@ -323,7 +323,7 @@ end
 --- Insert to lua table into sqlite database table.
 ---@params tbl string: the table name
 ---@params rows table: rows to insert to the table.
----@return boolean, integer: true incase the table was inserted successfully, and the last inserted row id
+---@return boolean|integer: true incase the table was inserted successfully, and the last inserted row id.
 ---@usage db:insert("todos", { title = "new todo" })
 ---@todo support unnamed or anonymous args
 ---@todo handle inconflict case

--- a/lua/sql/table.lua
+++ b/lua/sql/table.lua
@@ -254,15 +254,15 @@ end
 ---@param rows table: a row or a group of rows
 ---@see t:__run()
 ---@see sql:insert()
----@return boolean
+---@return boolean, integer
 function t:insert(rows)
   return self:__run(function()
-    local succ = self.db:insert(self.name, rows)
+    local succ, last_rowid = self.db:insert(self.name, rows)
     self:__clear_cache(succ, rows)
     if succ then
       self.has_content = self:count() ~= 0 or false
     end
-    return succ
+    return succ, last_rowid
   end)
 end
 

--- a/lua/sql/table.lua
+++ b/lua/sql/table.lua
@@ -254,7 +254,7 @@ end
 ---@param rows table: a row or a group of rows
 ---@see t:__run()
 ---@see sql:insert()
----@return boolean, integer
+---@return boolean|integer
 function t:insert(rows)
   return self:__run(function()
     local succ, last_rowid = self.db:insert(self.name, rows)

--- a/test/auto/sql_spec.lua
+++ b/test/auto/sql_spec.lua
@@ -244,21 +244,25 @@ describe("sql", function()
   describe(':insert', function()
     local db = sql:open()
     assert(db:eval("create table todos(title text, desc text)"))
+    local ex_last_rowid = 0
 
     it('inserts a single row', function()
-      db:insert("todos", {
+      local rows = {
         title = "TODO 1",
         desc = "................",
-      })
-      local results = db:eval("select * from todos")
+      }
+      local _, last_row_id = db:insert("todos", rows)
+      ex_last_rowid = ex_last_rowid + 1
+      local results = db:eval("select rowid, * from todos")
       eq(true, type(results) == "table", "It should be inserted.")
+      eq(last_row_id, results[1].rowid, "It should be equals to the returned last inserted rowid " .. last_row_id)
       eq("TODO 1", results[1].title)
       eq("................", results[1].desc)
       db:eval("delete from todos")
     end)
 
     it('inserts multiple rows', function()
-      db:insert("todos", {
+      local rows = {
         {
           title = "todo 3",
           desc = "...",
@@ -271,8 +275,11 @@ describe("sql", function()
           title = "todo 1",
           desc = "...",
         },
-      })
-      local store = db:eval("select * from todos")
+      }
+      local _, rowid = db:insert("todos", rows)
+      ex_last_rowid = ex_last_rowid + #rows
+      local store = db:eval("select rowid, * from todos")
+      eq(rowid, store[#store].rowid, "It should be equals to the returned last inserted rowid " .. rowid)
       eq(3, vim.tbl_count(store))
       for _, v in ipairs(store) do
         eq(true, v.desc == "...")

--- a/test/auto/table_spec.lua
+++ b/test/auto/table_spec.lua
@@ -346,10 +346,14 @@ describe('table', function()
   seed()
 
   describe(":insert", function()
+    local ex_last_rowid = #demo
     it("inserts a row", function()
-      local new_rows = { a = 109,  b = "0", c = "0" }
-      eq(true, t1:insert(new_rows), "it should return true")
-      eq({new_rows}, db:eval("select * from T where a = 109"), "it should have the new rows")
+      local new_row = { a = 109,  b = "0", c = "0" }
+      ex_last_rowid = ex_last_rowid + 1
+      local succ, last_rowid = t1:insert(new_row)
+      eq(true, succ, "it should return true")
+      eq(ex_last_rowid, last_rowid, "it should return row_id " .. ex_last_rowid)
+      eq({new_row}, db:eval("select * from T where a = 109"), "it should have the new rows")
     end)
 
     it("inserts a list of rows", function()
@@ -358,7 +362,10 @@ describe('table', function()
         { a = 22, b = "sdj", c = "in" },
         { a = 33, b = "sbs", c = "en" }
       }
-      eq(true, t1:insert(new_rows), "it should return true")
+      ex_last_rowid = ex_last_rowid + #new_rows
+      local succ, last_rowid = t1:insert(new_rows)
+      eq(true, succ, "it should return true")
+      eq(ex_last_rowid, last_rowid, "it should return row_id " .. ex_last_rowid)
       eq(new_rows, db:eval("select * from T where a = 11 or a = 22 or a = 33"), "it should have the new rows")
     end)
   end)


### PR DESCRIPTION
This change allows for `db:insert()` and `t:insert()` to return the last inserted row id as a second return value, provided by sql. The process is done after the rows statements have been completed but finishing the transaction to guarantee the value integrity. This closes #46 

The interface to users doesn't change thanks to lua useful adjustment. https://www.lua.org/pil/5.1.html I'm sure you know @tami5  I just like to document my PR :)

I've also added tests.

If you agree with the changes and the tests I can update the readme to reflect the changes.