### PR TITLE
fix: enable select limit and tests.

### DIFF
--- a/lua/sql.lua
+++ b/lua/sql.lua
@@ -420,6 +420,7 @@ end
 --- Query from a table with where and join options
 ---@usage db:get("todos") -- everything
 ---@usage db:get("todos", { where = { id = 1 })
+---@usage db:get("todos", { limit = 5 })
 -- @return lua list of matching rows
 function sql:select(tbl, spec)
   self:__assert_tbl(tbl, "select")
@@ -433,6 +434,7 @@ function sql:select(tbl, spec)
       select = spec.select,
       where = spec.where,
       join = spec.join,
+      limit = spec.limit,
     })) or self:__parse(P.select(tbl))
 
     s:each(function()

--- a/test/auto/sql_spec.lua
+++ b/test/auto/sql_spec.lua
@@ -586,6 +586,13 @@ describe("sql", function()
 
       eq(expected, res[1])
     end)
+
+    it('return respecting a limit', function()
+      local limit = 5
+      local res = db:select("posts", { limit = limit })
+      eq(#res, limit, "they should be the same")
+    end)
+
     it("it serialize json if the schema key datatype is json", function()
       db:eval("create table test(id integer, data luatable)")
       db:eval("insert into test(id,data) values(1, '[\"list\",\"of\",\"lines\"]')")

--- a/test/auto/table_spec.lua
+++ b/test/auto/table_spec.lua
@@ -129,6 +129,14 @@ describe('table', function()
       demo[1].a = 1
     end)
 
+    it("runs a query and returns results (keys & limit)", function()
+      local limit = 3
+      local res = t1:get{ keys = { "a" }, limit = limit }
+      eq(res[1].b, nil, "should not have the key")
+      eq(res[1].c, nil, "should not have the key")
+      eq(#res, limit, "they should be the same")
+    end)
+
     it("runs a query from cache.", function()
       local res = t1:get{ keys = { "b", "c" }, where = { a = 1 } }
       t1.cache["keys=bc,select=bc,where=a=1"][1].b = "bddddd"


### PR DESCRIPTION
Support was existent in the parser but seems like it was forgotten 😢 . So added some tests as well. 😄 

As a side note there's a test failing:
```
Fail    ||      sql :insert respects sqlvalues defaults
            ...m/site/pack/packer/start/sql.nvim/test/auto/sql_spec.lua:326: It should be equals to the returned last inserted rowid
 3
            Expected objects to be the same.
            Passed in:
            (string) '2021-08-05'
            Expected:
            (string) '2021-08-04'

            stack traceback:
                ...m/site/pack/packer/start/sql.nvim/test/auto/sql_spec.lua:326: in function <...m/site/pack/packer/start/sql.nvim/t
est/auto/sql_spec.lua:320>

```

The `It should be equals to the returned last inserted rowid` is a quirk on buster, since it doesn't error out there but is the previous `eq` that provides a string explanation which is in line 282, while the error is actually on 326. So seems like buster is just forgetting to clean up when stepping the assertions.