### PR TITLE
:sparkles: use dot notiation with extended tbl object

### DIFF
--- a/doc/sql.txt
+++ b/doc/sql.txt
@@ -409,14 +409,14 @@ SQLTableExt                                                      *SQLTableExt*
                           methods.
 
 
-tbl:new({db}, {name}, {opts})                                      *tbl:new()*
+tbl:new({db}, {name}, {schema})                                    *tbl:new()*
     Create new sql table object
 
 
     Parameters: ~
-        {db}   (SQLDatabase)
-        {name} (string)        table name
-        {opts} (SQLTableOpts)
+        {db}     (SQLDatabase)
+        {name}   (string)       table name
+        {schema} (table)        table schema
 
     Return: ~
         SQLTable

--- a/doc/sql.txt
+++ b/doc/sql.txt
@@ -401,14 +401,6 @@ SQLTableOpts                                                    *SQLTableOpts*
         {schema} (table)  <string, string>
 
 
-SQLTableExt                                                      *SQLTableExt*
-    SQLTable
-
-    Fields: ~
-        {tbl} (SQLTable)  fallback when the user overwrite @SQLTableExt
-                          methods.
-
-
 tbl:new({db}, {name}, {schema})                                    *tbl:new()*
     Create new sql table object
 
@@ -420,6 +412,21 @@ tbl:new({db}, {name}, {schema})                                    *tbl:new()*
 
     Return: ~
         SQLTable
+
+
+tbl:extend({db}, {name}, {schema})                              *tbl:extend()*
+    Extend Sqlite Table Object. if first argument is {name} then second should
+    be {schema}. If no {db} is provided, the tbl object won't be initialized
+    until tbl.set_db is called
+
+
+    Parameters: ~
+        {db}     (SQLDatabase)
+        {name}   (string)
+        {schema} (table)
+
+    Return: ~
+        SQLTableExt
 
 
 tbl:schema({schema})                                            *tbl:schema()*
@@ -650,20 +657,6 @@ tbl:replace({rows})                                            *tbl:replace()*
     See: ~
         |DB:delete()|
         |DB:insert()|
-
-
-tbl:extend({db}, {name}, {schema})                              *tbl:extend()*
-    Extend Sqlite Table Object. if first argument is {name} then second should
-    be {schema}.
-
-
-    Parameters: ~
-        {db}     (SQLDatabase)
-        {name}   (string)
-        {schema} (table)
-
-    Return: ~
-        SQLTableExt
 
 
 

--- a/doc/sql.txt
+++ b/doc/sql.txt
@@ -394,13 +394,6 @@ SQLTable                                                            *SQLTable*
         {db} (SQLDatabase)  database in which the tbl is part of.
 
 
-SQLTableOpts                                                    *SQLTableOpts*
-    Supported sql.table configurations.
-
-    Fields: ~
-        {schema} (table)  <string, string>
-
-
 tbl:new({db}, {name}, {schema})                                    *tbl:new()*
     Create new sql table object
 

--- a/doc/sql.txt
+++ b/doc/sql.txt
@@ -652,14 +652,15 @@ tbl:replace({rows})                                            *tbl:replace()*
         |DB:insert()|
 
 
-tbl:extend({db}, {name}, {opts})                                *tbl:extend()*
-    Extend Sqlite Table Object.
+tbl:extend({db}, {name}, {schema})                              *tbl:extend()*
+    Extend Sqlite Table Object. if first argument is {name} then second should
+    be {schema}.
 
 
     Parameters: ~
-        {db}   (SQLDatabase)
-        {name} (string)
-        {opts} (table)
+        {db}     (SQLDatabase)
+        {name}   (string)
+        {schema} (table)
 
     Return: ~
         SQLTableExt

--- a/lua/sql/assert.lua
+++ b/lua/sql/assert.lua
@@ -9,6 +9,7 @@ local errors = {
   eval_fail = "eval has failed to execute statement, ERRMSG: %s",
   failed_ops = "operation failed, ERRMSG: %s",
   missing_req_key = "(insert) missing a required key: %s",
+  missing_db_object = "'%s' db object is not set. please set it with `tbl.set_db(db)` and try again.",
 }
 
 for key, value in pairs(errors) do
@@ -56,6 +57,11 @@ end
 
 M.missing_req_key = function(val, key)
   assert(val, errors.missing_req_key:format(key))
+  return false
+end
+
+M.should_have_db_object = function(db, name)
+  assert(db ~= nil, errors.missing_db_object:format(name))
   return false
 end
 

--- a/lua/sql/parser.lua
+++ b/lua/sql/parser.lua
@@ -393,7 +393,6 @@ M.create = function(tbl, defs)
 
   for k, v in u.opairs(defs) do
     local t = type(v)
-    local islist = u.is_list(v)
     if t == "boolean" then
       tinsert(items, k .. " integer not null primary key")
     elseif t ~= "table" then

--- a/lua/sql/table.lua
+++ b/lua/sql/table.lua
@@ -242,11 +242,11 @@ function tbl:sort(query, transform, comp)
         return r[transform]
       end
     end
-    comp = comp or function(a, b)
-      return a < b
+    comp = comp or function(_a, _b)
+      return _a < _b
     end
-    table.sort(res, function(a, b)
-      return comp(f(a), f(b))
+    table.sort(res, function(_a, _b)
+      return comp(f(_a), f(_b))
     end)
     return res
   end, self)
@@ -319,12 +319,12 @@ function tbl:extend(db, name, schema)
   end
 
   local t = self:new(db, name, { schema = schema })
-  t.set_db = function(db)
-    t.db = db
+  t.set_db = function(o)
+    t.db = o
   end
 
   return setmetatable({}, {
-    __index = function(self, key, ...)
+    __index = function(_, key, ...)
       return type(t[key]) == "function" and function(...)
         return t[key](t, ...)
       end or t[key]

--- a/lua/sql/table.lua
+++ b/lua/sql/table.lua
@@ -308,31 +308,33 @@ end
 ---@class SQLTableExt:SQLTable
 ---@field tbl SQLTable: fallback when the user overwrite @SQLTableExt methods.
 
----Extend Sqlite Table Object.
+---Extend Sqlite Table Object. if first argument is {name} then second should be {schema}.
 ---@param db SQLDatabase
 ---@param name string
----@param opts table
+---@param schema table
 ---@return SQLTableExt
 function tbl:extend(db, name, schema)
   if not schema and type(db) == "string" then
     name, db, schema = db, nil, name
   end
+
   local t = self:new(db, name, { schema = schema })
-  local o = { tbl = {}, _tbl = t }
+  local o = {}
 
   for key, value in pairs(t) do
-    o.tbl[key] = value
+    o[key] = value
   end
 
   for key, value in pairs(getmetatable(t)) do
     if type(value) == "function" then
-      o.tbl[key] = function(...)
+      o[key] = function(...)
         return t[key](t, ...)
       end
+      o["_" .. key] = o[key]
     end
   end
 
-  o.tbl.set_db = function(db)
+  o.set_db = function(db)
     t.db = db
   end
 

--- a/lua/sql/table/extend.lua
+++ b/lua/sql/table/extend.lua
@@ -1,0 +1,116 @@
+---@class SQLTableExt
+---@field db SQLDatabase
+---@field name string: table name
+---@field mtime number: db last modified time
+local tbl = {}
+
+---Create or change table schema. If no {schema} is given,
+---then it return current the used schema if it exists or empty table otherwise.
+---On change schema it returns boolean indecting success.
+---@param schema table: table schema definition
+---@return table table | boolean
+---@usage `tbl.schema()` get project table schema.
+---@usage `tbl.schema({...})` mutate project table schema
+---@todo do alter when updating the schema instead of droping it completely
+tbl.schema = function(schema) end
+
+---Remove table from database, if the table is already drooped then it returns false.
+---@usage `todos:drop()` drop todos table content.
+---@see DB:drop
+---@return boolean
+tbl.drop = function() end
+
+---Predicate that returns true if the table is empty.
+---@usage `if todos:empty() then echo "no more todos, you are free :D" end`
+---@return boolean
+tbl.empty = function() end
+
+---Predicate that returns true if the table exists.
+---@usage `if not goals:exists() then error("I'm disappointed in you ") end`
+---@return boolean
+tbl.exists = function() end
+
+---Query the table and return results.
+---@param query table: query.where, query.keys, query.join
+---@return table
+---@usage `tbl.get()` get a list of all rows in project table.
+---@usage `tbl.get({ where = { status = "pending", client = "neovim" }})`
+---@usage `tbl.get({ where = { status = "done" }, limit = 5})` get the last 5 done projects
+---@see DB:select
+tbl.get = function(query) end
+
+---Get the current number of rows in the table
+---@return number
+tbl.count = function() end
+
+---Get first match.
+---@param where table: where key values
+---@return nil or row
+---@usage `tbl.where{id = 1}`
+---@see DB:select
+tbl.where = function(where) end
+
+---Iterate over table rows and execute {func}.
+---Returns true only when rows is not emtpy.
+---@param func function: func(row)
+---@param query table: query.where, query.keys, query.join
+---@usage `let query = { where = { status = "pending"}, contains = { title = "fix*" } }`
+---@usage `tbl.each(function(row) print(row.title) end, query)`
+---@return boolean
+tbl.each = function(func, query) end
+
+---Create a new table from iterating over {self.name} rows with {func}.
+---@param func function: func(row)
+---@param query table: query.where, query.keys, query.join
+---@usage `let query = { where = { status = "pending"}, contains = { title = "fix*" } }`
+---@usage `local t = todos.map(function(row) return row.title end, query)`
+---@return table[]
+tbl.map = function(func, query) end
+
+---Sorts a table in-place using a transform. Values are ranked in a custom order of the results of
+---running `transform (v)` on all values. `transform` may also be a string name property  sort by.
+---`comp` is a comparison function. Adopted from Moses.lua
+---@param query table: query.where, query.keys, query.join
+---@param transform function: a `transform` function to sort elements. Defaults to @{identity}
+---@param comp function: a comparison function, defaults to the `<` operator
+---@return table[]
+---@usage `local res = tbl.sort({ where = {id = {32,12,35}}})` return rows sort by id
+---@usage `local res = tbl.sort({ where = {id = {32,12,35}}}, "age")` return rows sort by age
+---@usage `local res = tbl.sort({where = { ... }}, "age", function(a, b) return a > b end)` with custom function
+tbl.sort = function(query, transform, comp) end
+
+---Same functionalities as |DB:insert()|
+---@param rows table: a row or a group of rows
+---@see DB:insert
+---@usage `tbl.insert { title = "stop writing examples :D" }` insert single item.
+---@usage `tbl.insert { { ... }, { ... } }` insert multiple items
+---@return integer: last inserted id
+tbl.insert = function(rows) end
+
+---Same functionalities as |DB:delete()|
+---@param where table: query
+---@see DB:delete
+---@return boolean
+---@usage `todos.remove()` remove todos table content.
+---@usage `todos.remove{ project = "neovim" }` remove all todos where project == "neovim".
+---@usage `todos.remove{{project = "neovim"}, {id = 1}}` remove all todos where project == "neovim" or id =1
+tbl.remove = function(where) end
+
+---Same functionalities as |DB:update()|
+---@param specs table: a table or a list of tables with where and values keys.
+---@see DB:update
+---@return boolean
+tbl.update = function(specs) end
+
+---replaces table content with {rows}
+---@param rows table: a row or a group of rows
+---@see DB:delete
+---@see DB:insert
+---@return boolean
+tbl.replace = function(rows) end
+
+---Set db object for the table.
+---@param db SQLDatabase
+tbl.set_db = function(db) end
+
+return tbl

--- a/lua/sql/utils.lua
+++ b/lua/sql/utils.lua
@@ -25,7 +25,7 @@ M.is_userdata = function(t)
 end
 
 M.is_nested = function(t)
-  return type(t[1]) == "table"
+  return t and type(t[1]) == "table" or false
 end
 
 -- taken from: https://github.com/neovim/neovim/blob/master/runtime/lua/vim/shared.lua

--- a/test/auto/sql_spec.lua
+++ b/test/auto/sql_spec.lua
@@ -823,7 +823,7 @@ describe("sql", function()
       manager:open()
       eq(true, manager:eval "insert into projects(title) values('sql.nvim')", "should insert.")
       eq("table", type(manager:eval("select * from projects")[1]), "should be have content even with self.db.")
-      eq(true, manager.projects:remove(), "projects table should work.")
+      eq(true, manager.projects.remove(), "projects table should work.")
     end)
 
     it("extending new object should work wihout issues", function()
@@ -836,23 +836,23 @@ describe("sql", function()
         },
       }
 
-      local id = manager.projects:insert(sqlnvim)
+      local id = manager.projects.insert(sqlnvim)
 
       eq(1, id, "should have returned id.")
-      eq(true, manager.projects:remove(), "should remove after default insert.")
+      eq(true, manager.projects.remove(), "should remove after default insert.")
 
-      function manager.projects:insert()
-        return self.tbl:insert(sqlnvim)
+      function manager.projects.insert()
+        return manager.projects.tbl.insert(sqlnvim)
       end
 
-      local id = manager.projects:insert()
+      local id = manager.projects.insert()
       eq(1, id, "should have returned id.")
 
-      function manager.projects:get()
-        return self.tbl:get({ where = { title = sqlnvim.title } })[1].title
+      function manager.projects.get()
+        return manager.projects.tbl.get({ where = { title = sqlnvim.title } })[1].title
       end
 
-      eq(sqlnvim.title, manager.projects:get(), "should have inserted sqlnvim project")
+      eq(sqlnvim.title, manager.projects.get(), "should have inserted sqlnvim project")
     end)
 
     it("control initialization", function()

--- a/test/auto/sql_spec.lua
+++ b/test/auto/sql_spec.lua
@@ -842,14 +842,14 @@ describe("sql", function()
       eq(true, manager.projects.remove(), "should remove after default insert.")
 
       function manager.projects.insert()
-        return manager.projects.tbl.insert(sqlnvim)
+        return manager.projects._insert(sqlnvim)
       end
 
       local id = manager.projects.insert()
       eq(1, id, "should have returned id.")
 
       function manager.projects.get()
-        return manager.projects.tbl.get({ where = { title = sqlnvim.title } })[1].title
+        return manager.projects._get({ where = { title = sqlnvim.title } })[1].title
       end
 
       eq(sqlnvim.title, manager.projects.get(), "should have inserted sqlnvim project")

--- a/test/auto/table_spec.lua
+++ b/test/auto/table_spec.lua
@@ -1,4 +1,5 @@
 local sql = require "sql"
+local tbl = require "sql.table"
 local eq = assert.are.same
 local demo = {
   { a = 1, b = "lsf", c = "de" },
@@ -28,6 +29,27 @@ end
 
 describe("table", function()
   local t1, t2 = seed()
+
+  describe(":extend", function()
+    it("missing db object", function()
+      local t = tbl("tbl_name", { id = true, name = "text" })
+      eq(false, pcall(t.insert, { name = "tami" }), "should fail early.")
+      t.set_db(db)
+      eq(true, pcall(t.insert, { name = "conni" }), "should work now we have a db object to operate against.")
+      eq({ { id = 1, name = "conni" } }, t.get(), "only insert conni")
+    end)
+
+    it("with db object", function()
+      local t = tbl(db, "tansactions", { id = true, amount = "real" })
+      eq(1, t.insert { amount = 20.2 })
+      eq(
+        "20.2",
+        t.map(function(row)
+          return tostring(row.amount)
+        end)[1]
+      )
+    end)
+  end)
 
   describe(":new", function()
     it("create new object with sql.table methods.", function()
@@ -368,29 +390,34 @@ describe("table", function()
   clean()
   describe("foreign key: ", function()
     local db = sql:open(nil)
-    local artists = db:table("artists", {
-      id = { type = "integer", pk = true },
-      name = "text",
-    })
-    local tracks = db:table("tracks", {
-      id = "integer",
-      name = "text",
-      artist = {
-        type = "integer",
-        reference = "artists.id",
-      },
-    })
+    local artists, tracks
+    it("create demo", function()
+      artists = db:table("artists", {
+        id = { type = "integer", pk = true },
+        name = "text",
+      })
+      tracks = db:table("tracks", {
+        id = "integer",
+        name = "text",
+        artist = {
+          type = "integer",
+          reference = "artists.id",
+        },
+      })
+    end)
 
-    artists:insert {
-      { id = 1, name = "Dean Martin" },
-      { id = 2, name = "Frank Sinatra" },
-    }
+    it("seed", function()
+      artists:insert {
+        { id = 1, name = "Dean Martin" },
+        { id = 2, name = "Frank Sinatra" },
+      }
 
-    tracks:insert {
-      { id = 11, name = "That's Amore", artist = 1 },
-      { id = 12, name = "Christmas Blues", artist = 1 },
-      { id = 13, name = "My Way", artist = 2 },
-    }
+      tracks:insert {
+        { id = 11, name = "That's Amore", artist = 1 },
+        { id = 12, name = "Christmas Blues", artist = 1 },
+        { id = 13, name = "My Way", artist = 2 },
+      }
+    end)
 
     local function try(self, action, args)
       return pcall(self[action], self, args)

--- a/test/auto/table_spec.lua
+++ b/test/auto/table_spec.lua
@@ -31,8 +31,9 @@ describe("table", function()
   local t1, t2 = seed()
 
   describe(":extend", function()
+    local t
     it("missing db object", function()
-      local t = tbl("tbl_name", { id = true, name = "text" })
+      t = tbl("tbl_name", { id = true, name = "text" })
       eq(false, pcall(t.insert, { name = "tami" }), "should fail early.")
       t.set_db(db)
       eq(true, pcall(t.insert, { name = "conni" }), "should work now we have a db object to operate against.")
@@ -40,7 +41,7 @@ describe("table", function()
     end)
 
     it("with db object", function()
-      local t = tbl(db, "tansactions", { id = true, amount = "real" })
+      t = tbl(db, "tansactions", { id = true, amount = "real" })
       eq(1, t.insert { amount = 20.2 })
       eq(
         "20.2",
@@ -48,6 +49,13 @@ describe("table", function()
           return tostring(row.amount)
         end)[1]
       )
+    end)
+
+    it("overwrite functions and fallback to t.db", function()
+      t.get = function()
+        return math.floor(t._get({ where = { id = 1 } })[1].amount)
+      end
+      eq(20, t.get())
     end)
   end)
 

--- a/test/auto/table_spec.lua
+++ b/test/auto/table_spec.lua
@@ -33,6 +33,7 @@ describe("table", function()
   describe(":extend", function()
     local t
     it("missing db object", function()
+      ---@type SQLTableExt
       t = tbl("tbl_name", { id = true, name = "text" })
       eq(false, pcall(t.insert, { name = "tami" }), "should fail early.")
       t.set_db(db)


### PR DESCRIPTION
#### Purpose

Try to make accessing table functions by dot notiation.

#### Details

When extending sql object or tables, there is rarely any case where the user need to pass self. Additionally, when dealing with tables inside db object, this `db.tbl.insert {...}` than `db.tbl:insert {..}`

I have no plans to support dot notation for db object as it would create confusion between accessing a table or call a method. 

Changes: 
+ Fix parsing schema key when using key value pairs.
+ access tbl original methods after overwrite with appending `_`, same goes to db extended object
  ```lua
  users.get = function()
    return users._get({ where = { id = 1 } })[1].name
  end
  ```
+ super lazy extend

TODO:

- [x] Update sql test related to extended tables
- [x] explore the possibility of using `t._get()` instead or `t.tbl.get()`
- [x] refactor `tbl:extend`
- [x] create new emmylua class definition for dot noted methods

followup: 
- [ ] create some examples in examples directory 