### PR TITLE
:bug: extended tables referencing mutable db table + other fixes

### DIFF
--- a/lua/sql.lua
+++ b/lua/sql.lua
@@ -99,7 +99,7 @@ function DB:extend(opts)
       local name = schema._name and schema._name or tbl_name
       cls[tbl_name] = schema.set_db and schema or t:extend(name, schema)
       if not cls[tbl_name].db then
-        cls[tbl_name].set_db(cls)
+        cls[tbl_name].set_db(cls.db)
       end
     end
   end

--- a/lua/sql/parser.lua
+++ b/lua/sql/parser.lua
@@ -418,17 +418,18 @@ end
 ---@param schema table tbl schema with extra info
 ---@return table pre processed rows
 M.pre_insert = function(rows, schema)
+  local res = {}
   rows = u.is_nested(rows) and rows or { rows }
-  for _, row in ipairs(rows) do
+  for i, row in ipairs(rows) do
     u.foreach(schema.req, function(k)
       a.missing_req_key(row[k], k)
     end)
-    u.foreach(row, function(k, v)
+    res[i] = u.map(row, function(v, k)
       local is_json = schema.types[k] == "luatable" or schema.types[k] == "json"
-      row[k] = is_json and json.encode(v) or M.sqlvalue(v)
+      return is_json and json.encode(v) or M.sqlvalue(v)
     end)
   end
-  return rows
+  return res
 end
 
 ---Postprocess data queried from a sql db. for now it is mainly used

--- a/lua/sql/table.lua
+++ b/lua/sql/table.lua
@@ -62,23 +62,22 @@ function tbl:extend(db, name, schema)
     name, db, schema = db, nil, name
   end
 
-  local t = tbl:new(db, name, { schema = schema })
+  local t = self:new(db, name, { schema = schema })
   return setmetatable({
     set_db = function(o)
       t.db = o
     end,
   }, {
-    __index = function(_, key, ...)
-      return type(t[key]) == "function" and function(...)
-        return t[key](t, ...)
-      end or t[key]
-    end,
-    __newindex = function(_, key, val)
-      if type(val) == "function" then
-        t["_" .. key] = t[key]
-        t[key] = val
-      else
-        t[key] = val
+    __index = function(o, key, ...)
+      if type(key) == "string" then
+        key = key:sub(1, 1) == "_" and key:sub(2, -1) or key
+        if type(t[key]) == "function" then
+          return function(...)
+            return t[key](t, ...)
+          end
+        else
+          return t[key]
+        end
       end
     end,
   })

--- a/lua/sql/table.lua
+++ b/lua/sql/table.lua
@@ -24,9 +24,6 @@ local run = function(func, o)
 
     if o.tbl_schema and next(o.tbl_schema) ~= nil and o.tbl_exists == false then
       o.tbl_schema.ensure = u.if_nil(o.tbl_schema.ensure, true)
-      if not o.db.create then
-        error(vim.inspect(o.db))
-      end
       o.db:create(o.name, o.tbl_schema)
     end
 
@@ -68,9 +65,6 @@ function tbl:extend(db, name, schema)
   local t = tbl:new(db, name, { schema = schema })
   return setmetatable({
     set_db = function(o)
-      if not o then
-        error(vim.inspect(db))
-      end
       t.db = o
     end,
   }, {
@@ -335,8 +329,5 @@ function tbl:replace(rows)
 end
 
 tbl = setmetatable(tbl, { __call = tbl.extend })
--- local db = require("sql").new "/tmp/dbfds.sql"
--- local t = tbl:extend("fatable", { id = true, name = "text" })
--- t.set_db(db)
--- print(vim.inspect(t.db))
+
 return tbl

--- a/test/auto/sql_spec.lua
+++ b/test/auto/sql_spec.lua
@@ -850,7 +850,16 @@ describe("sql", function()
         return manager.projects._get({ where = { title = sqlnvim.title } })[1].title
       end
 
+      function manager.projects.objectives()
+        return manager.projects._get({ where = { id = 1 } })[1].objectives
+      end
+
       eq(sqlnvim.title, manager.projects.get(), "should have inserted sqlnvim project")
+      eq(true, manager.projects.objectives() ~= "")
+      eq(true, manager.projects.update { where = { id = 1 }, set = { objectives = "" } })
+      eq("", manager.projects._get({ where = { id = 1 } })[1].objectives)
+      eq("table", type(sqlnvim.objectives), "It shouldn't have changed")
+      eq("", manager.projects.where({ id = 1 }).objectives)
     end)
 
     it("set a different name for sql db table, with access using extend field", function()

--- a/test/auto/sql_spec.lua
+++ b/test/auto/sql_spec.lua
@@ -772,8 +772,8 @@ describe("sql", function()
   end)
 
   describe(":extend", function()
-    local testrui = "/tmp/extend_db"
-    local testrui2 = "/tmp/extend_db2"
+    local testrui = "/tmp/extend_db_new"
+    local testrui2 = "/tmp/extend_db_new5"
     local ok, manager
 
     it("Initialize manager", function()
@@ -803,7 +803,7 @@ describe("sql", function()
     end)
 
     it("process opts and set sql table objects", function()
-      eq("/tmp/extend_db", manager.uri, "should set self.uri.")
+      eq("/tmp/extend_db_new", manager.uri, "should set self.uri.")
       eq(true, manager.closed, "should construct without openning connection.")
       eq(nil, manager.conn, "should not set connection object.")
       eq("boolean", type(manager.sqlite_opts.foreign_keys), "should have added opts to sqlite_opts.")
@@ -833,33 +833,28 @@ describe("sql", function()
         },
       }
 
-      local id = manager.projects.insert(sqlnvim)
-
-      eq("cdata", type(manager.conn), "should set connection object.")
-      eq(1, id, "should have returned id.")
+      eq(1, manager.projects.insert(sqlnvim), "should insert and return id.")
+      eq("cdata", type(manager.conn), "should set connection object after first call to sql api")
+      eq("table", type(manager.projects.where({ id = 1 }).objectives), "should return as table.")
+      eq("table", type(sqlnvim.objectives), "It shouldn't have mutated objectives table.")
       eq(true, manager.projects.remove(), "should remove after default insert.")
 
       function manager.projects.insert()
         return manager.projects._insert(sqlnvim)
       end
-
-      local id = manager.projects.insert()
-      eq(1, id, "should have returned id.")
-
       function manager.projects.get()
-        return manager.projects._get({ where = { title = sqlnvim.title } })[1].title
+        return manager.projects._get({ where = { title = sqlnvim.title } })[1]
+      end
+      function manager.projects.remove_objectives()
+        return manager.projects.update { where = { id = 1 }, set = { objectives = {} } }
       end
 
-      function manager.projects.objectives()
-        return manager.projects._get({ where = { id = 1 } })[1].objectives
-      end
+      eq(1, manager.projects.insert(), "should have inserted and returned id.")
 
-      eq(sqlnvim.title, manager.projects.get(), "should have inserted sqlnvim project")
-      eq(true, manager.projects.objectives() ~= "")
-      eq(true, manager.projects.update { where = { id = 1 }, set = { objectives = "" } })
-      eq("", manager.projects._get({ where = { id = 1 } })[1].objectives)
-      eq("table", type(sqlnvim.objectives), "It shouldn't have changed")
-      eq("", manager.projects.where({ id = 1 }).objectives)
+      eq(sqlnvim.title, manager.projects.get().title, "should have inserted sqlnvim project")
+      eq(true, manager.projects.get().objectives ~= "")
+      eq(true, manager.projects.remove_objectives(), "should succeed at updating")
+      eq({}, manager.projects.get().objectives, "should return empty table")
     end)
 
     it("set a different name for sql db table, with access using extend field", function()


### PR DESCRIPTION
#### Purpose

table.extend should stop referencing the abstraction over the db object and just reference the underlying db object. This fixed some extend table function failing due to overwrite of original table function.

Additionally, it seems that JSON parsing seems to be broken some how as shown in the tests.

closes #99 
