### PR TITLE
:sparkles: auto alter table key definition 

### DIFF
--- a/doc/sql.txt
+++ b/doc/sql.txt
@@ -16,6 +16,29 @@ SQLDatabase                                                      *SQLDatabase*
         {conn} (sqlite3_blob)  sqlite connection c object.
 
 
+SqlSchemaKeyDefinition                                *SqlSchemaKeyDefinition*
+
+
+    Fields: ~
+        {cid}       (number)         column index
+        {name}      (string)         column key
+        {type}      (string)         column type
+        {required}  (boolean)        whether the column key is required or not
+        {primary}   (boolean)        whether the column is a primary key
+        {default}   (string)         the default value of the column
+        {reference} (string)         table_name.column
+        {on_update} (SqliteActions)  what to do when the key gets updated
+        {on_delete} (SqliteActions)  what to do when the key gets deleted
+
+
+SQLQuerySpec                                                    *SQLQuerySpec*
+    Query spec that are passed to a number of db: methods.
+
+    Fields: ~
+        {where}  (table)  key and value
+        {values} (table)  key and value to updated.
+
+
 SQLDatabaseExt : SQLDatabase                                  *SQLDatabaseExt*
     Extend sql.nvim object
 

--- a/doc/sql.txt
+++ b/doc/sql.txt
@@ -166,17 +166,6 @@ DB:status()                                                      *DB:status()*
         SQLDatabaseStatus
 
 
-DB:execute({statement})                                         *DB:execute()*
-    Execute statement without any return
-
-
-    Parameters: ~
-        {statement} (string)  statement to be executed
-
-    Return: ~
-        boolean: true if successful, error out if not.
-
-
 DB:eval({statement}, {params})                                     *DB:eval()*
     Evaluates a sql {statement} and if there are results from evaluating it
     then the function returns list of row(s). Else, it returns a boolean
@@ -201,6 +190,17 @@ DB:eval({statement}, {params})                                     *DB:eval()*
         value.
         `db:eval("insert into t(a, b) values(:a, :b)", {a = "1", b = 3})`
         evaluate with named arguments.
+
+
+DB:execute({statement})                                         *DB:execute()*
+    Execute statement without any return
+
+
+    Parameters: ~
+        {statement} (string)  statement to be executed
+
+    Return: ~
+        boolean: true if successful, error out if not.
 
 
 DB:exists({tbl_name})                                            *DB:exists()*

--- a/doc/sql.txt
+++ b/doc/sql.txt
@@ -16,6 +16,29 @@ SQLDatabase                                                      *SQLDatabase*
         {conn} (sqlite3_blob)  sqlite connection c object.
 
 
+SqlSchemaKeyDefinition                                *SqlSchemaKeyDefinition*
+
+
+    Fields: ~
+        {cid}       (number)         column index
+        {name}      (string)         column key
+        {type}      (string)         column type
+        {required}  (boolean)        whether the column key is required or not
+        {primary}   (boolean)        whether the column is a primary key
+        {default}   (string)         the default value of the column
+        {reference} (string)         table_name.column
+        {on_update} (SqliteActions)  what to do when the key gets updated
+        {on_delete} (SqliteActions)  what to do when the key gets deleted
+
+
+SQLQuerySpec                                                    *SQLQuerySpec*
+    Query spec that are passed to a number of db: methods.
+
+    Fields: ~
+        {where}  (table)  key and value
+        {values} (table)  key and value to updated.
+
+
 SQLDatabaseExt : SQLDatabase                                  *SQLDatabaseExt*
     Extend sql.nvim object
 
@@ -247,6 +270,36 @@ DB:drop({tbl_name})                                                *DB:drop()*
 
     Usage: ~
         `db:drop("todos")` drop table.
+
+
+DB:schema({tbl_name})                                            *DB:schema()*
+    Get {name} table schema, if table does not exist then return an empty
+    table.
+
+
+    Parameters: ~
+        {tbl_name} (string)  the table name.
+
+    Return: ~
+        table<string, SqlSchemaKeyDefinition>
+
+
+DB:insert({tbl_name}, {rows})                                    *DB:insert()*
+    Insert to lua table into sqlite database table. returns true incase the
+    table was inserted successfully, and the last inserted row id.
+
+
+    Parameters: ~
+        {tbl_name} (string)  the table name
+        {rows}     (table)   rows to insert to the table.
+
+    Return: ~
+        boolean|integer
+
+    Usage: ~
+        `db:insert("todos", { title = "new todo" })` single item.
+        `db:insert("items", { { name = "a"}, { name = "b" }, { name = "c" }
+        })` insert multiple items.
 
 
 DB:update({tbl_name}, {specs})                                   *DB:update()*

--- a/doc/sql.txt
+++ b/doc/sql.txt
@@ -16,29 +16,6 @@ SQLDatabase                                                      *SQLDatabase*
         {conn} (sqlite3_blob)  sqlite connection c object.
 
 
-SqlSchemaKeyDefinition                                *SqlSchemaKeyDefinition*
-
-
-    Fields: ~
-        {cid}       (number)         column index
-        {name}      (string)         column key
-        {type}      (string)         column type
-        {required}  (boolean)        whether the column key is required or not
-        {primary}   (boolean)        whether the column is a primary key
-        {default}   (string)         the default value of the column
-        {reference} (string)         table_name.column
-        {on_update} (SqliteActions)  what to do when the key gets updated
-        {on_delete} (SqliteActions)  what to do when the key gets deleted
-
-
-SQLQuerySpec                                                    *SQLQuerySpec*
-    Query spec that are passed to a number of db: methods.
-
-    Fields: ~
-        {where}  (table)  key and value
-        {values} (table)  key and value to updated.
-
-
 SQLDatabaseExt : SQLDatabase                                  *SQLDatabaseExt*
     Extend sql.nvim object
 

--- a/doc/sql.txt
+++ b/doc/sql.txt
@@ -8,32 +8,12 @@ https://github.com/tami5/sql.nvim
   :h sql
   :h sql.table
 
-SqlSchemaKeyDefinition                                *SqlSchemaKeyDefinition*
-
-
-    Fields: ~
-        {cid}      (number)         column index
-        {name}     (string)         column key
-        {type}     (string)         column type
-        {required} (boolean)        whether the column key is required or not
-        {primary}  (boolean)        whether the column is a primary key
-        {default}  (string|number)  the default value of the column
-
-
 SQLDatabase                                                      *SQLDatabase*
     Main sql.nvim object.
 
     Fields: ~
         {uri}  (string)        database uri
         {conn} (sqlite3_blob)  sqlite connection c object.
-
-
-SQLQuerySpec                                                    *SQLQuerySpec*
-    Query spec that are passed to a number of db: methods.
-
-    Fields: ~
-        {where}  (table)  key and value
-        {values} (table)  key and value to updated.
 
 
 SQLDatabaseExt : SQLDatabase                                  *SQLDatabaseExt*
@@ -191,7 +171,10 @@ DB:execute({statement})                                         *DB:execute()*
 
 
     Parameters: ~
-        {statement} (string)
+        {statement} (string)  statement to be executed
+
+    Return: ~
+        boolean: true if successful, error out if not.
 
 
 DB:eval({statement}, {params})                                     *DB:eval()*
@@ -241,8 +224,8 @@ DB:create({tbl_name}, {schema})                                  *DB:create()*
 
 
     Parameters: ~
-        {tbl_name} (string)  table name
-        {schema}   (table)   the table keys/column and their types
+        {tbl_name} (string)                                 table name
+        {schema}   (table<string, SqlSchemaKeyDefinition>)
 
     Return: ~
         boolean
@@ -365,8 +348,8 @@ tbl:new({db}, {name}, {schema})                                    *tbl:new()*
 
     Parameters: ~
         {db}     (SQLDatabase)
-        {name}   (string)       table name
-        {schema} (table)        table schema
+        {name}   (string)                                 table name
+        {schema} (table<string, SqlSchemaKeyDefinition>)
 
     Return: ~
         SQLTable
@@ -381,7 +364,7 @@ tbl:extend({db}, {name}, {schema})                              *tbl:extend()*
     Parameters: ~
         {db}     (SQLDatabase)
         {name}   (string)
-        {schema} (table)
+        {schema} (table<string, SqlSchemaKeyDefinition>)
 
     Return: ~
         SQLTableExt
@@ -394,10 +377,10 @@ tbl:schema({schema})                                            *tbl:schema()*
 
 
     Parameters: ~
-        {schema} (table)  table schema definition
+        {schema} (table<string, SqlSchemaKeyDefinition>)
 
     Return: ~
-        table table | boolean
+        table<string, SqlSchemaKeyDefinition> | boolean
 
     Usage: ~
         `projects:schema()` get project table schema.

--- a/doc/sql.txt
+++ b/doc/sql.txt
@@ -8,6 +8,18 @@ https://github.com/tami5/sql.nvim
   :h sql
   :h sql.table
 
+SqlSchemaKeyDefinition                                *SqlSchemaKeyDefinition*
+
+
+    Fields: ~
+        {cid}      (number)         column index
+        {name}     (string)         column key
+        {type}     (string)         column type
+        {required} (boolean)        whether the column key is required or not
+        {primary}  (boolean)        whether the column is a primary key
+        {default}  (string|number)  the default value of the column
+
+
 SQLDatabase                                                      *SQLDatabase*
     Main sql.nvim object.
 
@@ -174,6 +186,14 @@ DB:status()                                                      *DB:status()*
         SQLDatabaseStatus
 
 
+DB:execute({statement})                                         *DB:execute()*
+    Execute statement without any return
+
+
+    Parameters: ~
+        {statement} (string)
+
+
 DB:eval({statement}, {params})                                     *DB:eval()*
     Evaluates a sql {statement} and if there are results from evaluating it
     then the function returns list of row(s). Else, it returns a boolean
@@ -244,36 +264,6 @@ DB:drop({tbl_name})                                                *DB:drop()*
 
     Usage: ~
         `db:drop("todos")` drop table.
-
-
-DB:schema({tbl_name})                                            *DB:schema()*
-    Get {name} table schema, if table does not exist then return an empty
-    table.
-
-
-    Parameters: ~
-        {tbl_name} (string)  the table name.
-
-    Return: ~
-        table list of keys or keys and their type.
-
-
-DB:insert({tbl_name}, {rows})                                    *DB:insert()*
-    Insert to lua table into sqlite database table. returns true incase the
-    table was inserted successfully, and the last inserted row id.
-
-
-    Parameters: ~
-        {tbl_name} (string)  the table name
-        {rows}     (table)   rows to insert to the table.
-
-    Return: ~
-        boolean|integer
-
-    Usage: ~
-        `db:insert("todos", { title = "new todo" })` single item.
-        `db:insert("items", { { name = "a"}, { name = "b" }, { name = "c" }
-        })` insert multiple items.
 
 
 DB:update({tbl_name}, {specs})                                   *DB:update()*

--- a/lua/sql.lua
+++ b/lua/sql.lua
@@ -24,6 +24,13 @@ local flags = clib.flags
 local DB = {}
 DB.__index = DB
 
+---@alias SqliteActions
+---| '"no action"' : Configuring "no action" means just that: when a parent key is modified or deleted from the database, no special action is taken.
+---| '"restrict"' : The "RESTRICT" action means that the application is prohibited from deleting (for ON DELETE RESTRICT) or modifying (for ON UPDATE RESTRICT) a parent key when there exists one or more child keys mapped to it.
+---| '"null"' : when a parent key is deleted (for ON DELETE SET NULL) or modified (for ON UPDATE SET NULL), the child key columns of all rows in the child table that mapped to the parent key are set to contain SQL NULL values.
+---| '"default"' : "default" actions are similar to "null", except that each of the child key columns is set to contain the column's default value instead of NULL.
+---| '"CASCADE"' : propagates the delete or update operation on the parent key to each dependent child key.
+
 ---@class SqlSchemaKeyDefinition
 ---@field cid number: column index
 ---@field name string: column key

--- a/lua/sql.lua
+++ b/lua/sql.lua
@@ -24,13 +24,6 @@ local flags = clib.flags
 local DB = {}
 DB.__index = DB
 
----@alias SqliteActions
----| '"no action"' : Configuring "no action" means just that: when a parent key is modified or deleted from the database, no special action is taken.
----| '"restrict"' : The "RESTRICT" action means that the application is prohibited from deleting (for ON DELETE RESTRICT) or modifying (for ON UPDATE RESTRICT) a parent key when there exists one or more child keys mapped to it.
----| '"null"' : when a parent key is deleted (for ON DELETE SET NULL) or modified (for ON UPDATE SET NULL), the child key columns of all rows in the child table that mapped to the parent key are set to contain SQL NULL values.
----| '"default"' : "default" actions are similar to "null", except that each of the child key columns is set to contain the column's default value instead of NULL.
----| '"CASCADE"' : propagates the delete or update operation on the parent key to each dependent child key.
-
 ---@class SqlSchemaKeyDefinition
 ---@field cid number: column index
 ---@field name string: column key
@@ -45,6 +38,13 @@ DB.__index = DB
 ---@class SQLQuerySpec @Query spec that are passed to a number of db: methods.
 ---@field where table: key and value
 ---@field values table: key and value to updated.
+
+---@alias SqliteActions
+---| '"no action"' : when a parent key is modified or deleted from the database, no special action is taken.
+---| '"restrict"' : prohibites from deleting (for ON DELETE RESTRICT) or modifying (for ON UPDATE RESTRICT) a parent key when there exists one or more child keys mapped to it.
+---| '"null"' : when a parent key is deleted or modified, the child key columns of all rows in the child table that mapped to the parent key are set to contain SQL NULL values.
+---| '"default"' : "default" actions are similar to "null", except that each of the child key columns is set to contain the column's default value instead of NULL.
+---| '"CASCADE"' : propagates the delete or update operation on the parent key to each dependent child key.
 
 ---Get a table schema, or execute a given function to get it
 ---@param schema table|nil

--- a/lua/sql.lua
+++ b/lua/sql.lua
@@ -77,14 +77,14 @@ function DB:open(uri, opts, noconn)
       uri = uri,
       conn = not noconn and clib.connect(uri, opts) or nil,
       closed = noconn and true or false,
-      sqlite_opts = opts,
+      opts = opts or {},
       modified = false,
       created = not noconn and os.date "%Y-%m-%d %H:%M:%S" or nil,
       tbl_schemas = {},
     }, self)
   else
     if self.closed or self.closed == nil then
-      self.conn = clib.connect(self.uri, self.sqlite_opts)
+      self.conn = clib.connect(self.uri, self.opts)
       self.created = os.date "%Y-%m-%d %H:%M:%S"
       self.closed = false
     end
@@ -272,7 +272,8 @@ end
 function DB:create(tbl_name, schema)
   local req = P.create(tbl_name, schema)
   if req:match "reference" then
-    self:eval "pragma foreign_keys = ON"
+    self:execute "pragma foreign_keys = ON"
+    self.opts.foreign_keys = true
   end
   return self:eval(req)
 end

--- a/lua/sql.lua
+++ b/lua/sql.lua
@@ -10,12 +10,26 @@
 ---@brief ]]
 ---@tag sql.lua
 
+local clib = require "sql.defs"
+local stmt = require "sql.stmt"
+local u = require "sql.utils"
+local a = require "sql.assert"
+local t = require "sql.table"
+local P = require "sql.parser"
+local flags = clib.flags
+
+---@class SQLDatabase @Main sql.nvim object.
+---@field uri string: database uri
+---@field conn sqlite3_blob: sqlite connection c object.
+local DB = {}
+DB.__index = DB
+
 ---@alias SqliteActions
----| '"no action"' : Configuring "no action" means just that: when a parent key is modified or deleted from the database, no special action is taken.
----| '"restrict"' : The "RESTRICT" action means that the application is prohibited from deleting (for ON DELETE RESTRICT) or modifying (for ON UPDATE RESTRICT) a parent key when there exists one or more child keys mapped to it.
----| '"null"' : when a parent key is deleted (for ON DELETE SET NULL) or modified (for ON UPDATE SET NULL), the child key columns of all rows in the child table that mapped to the parent key are set to contain SQL NULL values.
----| '"default"' : "default" actions are similar to "null", except that each of the child key columns is set to contain the column's default value instead of NULL.
----| '"CASCADE"' : propagates the delete or update operation on the parent key to each dependent child key.
+---| '"no action"'
+---| '"restrict"'
+---| '"null"'
+---| '"default"'
+---| '"CASCADE"'
 
 ---@class SqlSchemaKeyDefinition
 ---@field cid number: column index
@@ -31,20 +45,6 @@
 ---@class SQLQuerySpec @Query spec that are passed to a number of db: methods.
 ---@field where table: key and value
 ---@field values table: key and value to updated.
-
-local clib = require "sql.defs"
-local stmt = require "sql.stmt"
-local u = require "sql.utils"
-local a = require "sql.assert"
-local t = require "sql.table"
-local P = require "sql.parser"
-local flags = clib.flags
-
----@class SQLDatabase @Main sql.nvim object.
----@field uri string: database uri
----@field conn sqlite3_blob: sqlite connection c object.
-local DB = {}
-DB.__index = DB
 
 ---Get a table schema, or execute a given function to get it
 ---@param schema table|nil

--- a/lua/sql.lua
+++ b/lua/sql.lua
@@ -24,13 +24,6 @@ local flags = clib.flags
 local DB = {}
 DB.__index = DB
 
----@alias SqliteActions
----| '"no action"' : Configuring "no action" means just that: when a parent key is modified or deleted from the database, no special action is taken.
----| '"restrict"' : The "RESTRICT" action means that the application is prohibited from deleting (for ON DELETE RESTRICT) or modifying (for ON UPDATE RESTRICT) a parent key when there exists one or more child keys mapped to it.
----| '"null"' : when a parent key is deleted (for ON DELETE SET NULL) or modified (for ON UPDATE SET NULL), the child key columns of all rows in the child table that mapped to the parent key are set to contain SQL NULL values.
----| '"default"' : "default" actions are similar to "null", except that each of the child key columns is set to contain the column's default value instead of NULL.
----| '"CASCADE"' : propagates the delete or update operation on the parent key to each dependent child key.
-
 ---@class SqlSchemaKeyDefinition
 ---@field cid number: column index
 ---@field name string: column key
@@ -39,8 +32,8 @@ DB.__index = DB
 ---@field primary boolean: whether the column is a primary key
 ---@field default string: the default value of the column
 ---@field reference string: table_name.column
----@field on_update SqliteActions
----@field on_delete SqliteActions
+---@field on_update SqliteActions: what to do when the key gets updated
+---@field on_delete SqliteActions: what to do when the key gets deleted
 
 ---@class SQLQuerySpec @Query spec that are passed to a number of db: methods.
 ---@field where table: key and value
@@ -297,12 +290,6 @@ function DB:drop(tbl_name)
   self.tbl_schemas[tbl_name] = nil
   return self:eval(P.drop(tbl_name))
 end
-
----TODO: Support customization inspired by
----https://simonwillison.net/2020/Sep/23/sqlite-advanced-alter-table/
--- function DB:alter(tbl_name, new_schema, old_schema)
---   return self:execute(P.alter(tbl_name, new_schema, old_schema or self:schema(tbl_name)))
--- end
 
 ---Get {name} table schema, if table does not exist then return an empty table.
 ---@param tbl_name string: the table name.

--- a/lua/sql.lua
+++ b/lua/sql.lua
@@ -41,10 +41,10 @@ DB.__index = DB
 
 ---@alias SqliteActions
 ---| '"no action"' : when a parent key is modified or deleted from the database, no special action is taken.
----| '"restrict"' : prohibites from deleting (for ON DELETE RESTRICT) or modifying (for ON UPDATE RESTRICT) a parent key when there exists one or more child keys mapped to it.
----| '"null"' : when a parent key is deleted or modified, the child key columns of all rows in the child table that mapped to the parent key are set to contain SQL NULL values.
----| '"default"' : "default" actions are similar to "null", except that each of the child key columns is set to contain the column's default value instead of NULL.
----| '"CASCADE"' : propagates the delete or update operation on the parent key to each dependent child key.
+---| '"restrict"' : prohibites from deleting/modifying a parent key when a child key is mapped to it.
+---| '"null"' : when a parent key is deleted/modified, the child key that mapped to the parent key gets set to null.
+---| '"default"' : similar to "null", except that sets to the column's default value instead of NULL.
+---| '"cascade"' : propagates the delete or update operation on the parent key to each dependent child key.
 
 ---Get a table schema, or execute a given function to get it
 ---@param schema table|nil

--- a/lua/sql.lua
+++ b/lua/sql.lua
@@ -10,13 +10,12 @@
 ---@brief ]]
 ---@tag sql.lua
 
-local clib = require "sql.defs"
-local stmt = require "sql.stmt"
-local u = require "sql.utils"
-local a = require "sql.assert"
-local t = require "sql.table"
-local P = require "sql.parser"
-local flags = clib.flags
+---@alias SqliteActions
+---| '"no action"' : Configuring "no action" means just that: when a parent key is modified or deleted from the database, no special action is taken.
+---| '"restrict"' : The "RESTRICT" action means that the application is prohibited from deleting (for ON DELETE RESTRICT) or modifying (for ON UPDATE RESTRICT) a parent key when there exists one or more child keys mapped to it.
+---| '"null"' : when a parent key is deleted (for ON DELETE SET NULL) or modified (for ON UPDATE SET NULL), the child key columns of all rows in the child table that mapped to the parent key are set to contain SQL NULL values.
+---| '"default"' : "default" actions are similar to "null", except that each of the child key columns is set to contain the column's default value instead of NULL.
+---| '"CASCADE"' : propagates the delete or update operation on the parent key to each dependent child key.
 
 ---@class SqlSchemaKeyDefinition
 ---@field cid number: column index
@@ -25,16 +24,27 @@ local flags = clib.flags
 ---@field required boolean: whether the column key is required or not
 ---@field primary boolean: whether the column is a primary key
 ---@field default string|number: the default value of the column
+---@field reference string: table_name.column
+---@field on_update SqliteActions
+---@field on_delete SqliteActions
+
+---@class SQLQuerySpec @Query spec that are passed to a number of db: methods.
+---@field where table: key and value
+---@field values table: key and value to updated.
+
+local clib = require "sql.defs"
+local stmt = require "sql.stmt"
+local u = require "sql.utils"
+local a = require "sql.assert"
+local t = require "sql.table"
+local P = require "sql.parser"
+local flags = clib.flags
 
 ---@class SQLDatabase @Main sql.nvim object.
 ---@field uri string: database uri
 ---@field conn sqlite3_blob: sqlite connection c object.
 local DB = {}
 DB.__index = DB
-
----@class SQLQuerySpec @Query spec that are passed to a number of db: methods.
----@field where table: key and value
----@field values table: key and value to updated.
 
 ---Get a table schema, or execute a given function to get it
 ---@param schema table|nil
@@ -186,7 +196,8 @@ function DB:status()
 end
 
 ---Execute statement without any return
----@param statement string
+---@param statement string: statement to be executed
+---@return boolean: true if successful, error out if not.
 function DB:execute(statement)
   local succ = clib.exec_stmt(self.conn, statement) == 0
   return succ and succ or error(clib.last_errmsg(self.conn))

--- a/lua/sql.lua
+++ b/lua/sql.lua
@@ -25,11 +25,11 @@ local DB = {}
 DB.__index = DB
 
 ---@alias SqliteActions
----| '"no action"'
----| '"restrict"'
----| '"null"'
----| '"default"'
----| '"CASCADE"'
+---| '"no action"' : Configuring "no action" means just that: when a parent key is modified or deleted from the database, no special action is taken.
+---| '"restrict"' : The "RESTRICT" action means that the application is prohibited from deleting (for ON DELETE RESTRICT) or modifying (for ON UPDATE RESTRICT) a parent key when there exists one or more child keys mapped to it.
+---| '"null"' : when a parent key is deleted (for ON DELETE SET NULL) or modified (for ON UPDATE SET NULL), the child key columns of all rows in the child table that mapped to the parent key are set to contain SQL NULL values.
+---| '"default"' : "default" actions are similar to "null", except that each of the child key columns is set to contain the column's default value instead of NULL.
+---| '"CASCADE"' : propagates the delete or update operation on the parent key to each dependent child key.
 
 ---@class SqlSchemaKeyDefinition
 ---@field cid number: column index
@@ -37,7 +37,7 @@ DB.__index = DB
 ---@field type string: column type
 ---@field required boolean: whether the column key is required or not
 ---@field primary boolean: whether the column is a primary key
----@field default string|number: the default value of the column
+---@field default string: the default value of the column
 ---@field reference string: table_name.column
 ---@field on_update SqliteActions
 ---@field on_delete SqliteActions
@@ -195,14 +195,6 @@ function DB:status()
   }
 end
 
----Execute statement without any return
----@param statement string: statement to be executed
----@return boolean: true if successful, error out if not.
-function DB:execute(statement)
-  local succ = clib.exec_stmt(self.conn, statement) == 0
-  return succ and succ or error(clib.last_errmsg(self.conn))
-end
-
 ---Evaluates a sql {statement} and if there are results from evaluating it then
 ---the function returns list of row(s). Else, it returns a boolean indecating
 ---whether the evaluation was successful. Optionally, the function accept
@@ -263,6 +255,14 @@ function DB:eval(statement, params)
   self.modified = true
 
   return res
+end
+
+---Execute statement without any return
+---@param statement string: statement to be executed
+---@return boolean: true if successful, error out if not.
+function DB:execute(statement)
+  local succ = clib.exec_stmt(self.conn, statement) == 0
+  return succ and succ or error(clib.last_errmsg(self.conn))
 end
 
 ---Check if a table with {tbl_name} exists in sqlite db

--- a/lua/sql.lua
+++ b/lua/sql.lua
@@ -277,7 +277,7 @@ end
 ---Create a new sqlite db table with {name} based on {schema}. if {schema.ensure} then
 ---create only when it does not exists. similar to 'create if not exists'.
 ---@param tbl_name string: table name
----@param schema table: the table keys/column and their types
+---@param schema table<string, SqlSchemaKeyDefinition>
 ---@usage `db:create("todos", {id = {"int", "primary", "key"}, title = "text"})` create table with the given schema.
 ---@return boolean
 function DB:create(tbl_name, schema)

--- a/lua/sql/assert.lua
+++ b/lua/sql/assert.lua
@@ -12,7 +12,7 @@ local errors = {
   missing_req_key = "(insert) missing a required key: %s",
   missing_db_object = "'%s' db object is not set. please set it with `tbl.set_db(db)` and try again.",
   outdated_schema = "`%s` does not exists in {`%s`}, schema is outdateset `self.db.tbl_schemas[table_name]` or reload",
-  auto_alter_more_less_keys = "sql.nvim: schema defined ~= db schema. Please drop `%s` table first or set ensure to false.",
+  auto_alter_more_less_keys = "schema defined ~= db schema. Please drop `%s` table first or set ensure to false.",
 }
 
 for key, value in pairs(errors) do

--- a/lua/sql/assert.lua
+++ b/lua/sql/assert.lua
@@ -12,6 +12,7 @@ local errors = {
   missing_req_key = "(insert) missing a required key: %s",
   missing_db_object = "'%s' db object is not set. please set it with `tbl.set_db(db)` and try again.",
   outdated_schema = "`%s` does not exists in {`%s`}, schema is outdateset `self.db.tbl_schemas[table_name]` or reload",
+  auto_alter_more_less_keys = "sql.nvim: schema defined ~= db schema. Please drop `%s` table first or set ensure to false.",
 }
 
 for key, value in pairs(errors) do
@@ -71,6 +72,12 @@ end
 M.should_have_db_object = function(db, name)
   assert(db ~= nil, errors.missing_db_object:format(name))
   return true
+end
+
+M.auto_alter_should_have_equal_len = function(len_new, len_old, tname)
+  if len_new - len_old ~= 0 then
+    error(errors.auto_alter_more_less_keys:format(tname))
+  end
 end
 
 return M

--- a/lua/sql/parser.lua
+++ b/lua/sql/parser.lua
@@ -472,7 +472,7 @@ M.table_alter_key_defs = function(tname, new, old, dry)
   local rename = ("ALTER TABLE %s RENAME TO %s"):format(tmpname, tname)
   local with_foregin_key = false
 
-  for key, def in pairs(new) do
+  for _, def in pairs(new) do
     if def.reference then
       with_foregin_key = true
     end

--- a/lua/sql/parser.lua
+++ b/lua/sql/parser.lua
@@ -341,7 +341,12 @@ local opts_to_str = function(tbl)
       end
     end,
     default = function(v)
-      return "default " .. v
+      local str = "default "
+      if tbl["required"] then
+        return "on conflict replace " .. str .. v
+      else
+        return str .. v
+      end
     end,
     reference = function(v)
       return ("references %s"):format(v:gsub("%.", "(") .. ")")
@@ -386,13 +391,13 @@ end
 ---@param tbl string: table name
 ---@param defs table: keys and type pairs
 ---@return string: the create sql statement.
-M.create = function(tbl, defs)
+M.create = function(tbl, defs, ignore_ensure)
   if not defs then
     return
   end
   local items = {}
 
-  tbl = defs.ensure and "if not exists " .. tbl or tbl
+  tbl = (defs.ensure and not ignore_ensure) and "if not exists " .. tbl or tbl
 
   for k, v in u.opairs(defs) do
     if k ~= "ensure" then
@@ -410,7 +415,7 @@ M.create = function(tbl, defs)
       end
     end
   end
-  return ("create table %s(%s)"):format(tbl, tconcat(items, ", "))
+  return ("CREATE TABLE %s(%s)"):format(tbl, tconcat(items, ", "))
 end
 
 ---Parse table drop statement
@@ -420,7 +425,81 @@ M.drop = function(tbl)
   return "drop table " .. tbl
 end
 
----Preporcess data insert to sql db.
+local same_type = function(new, old)
+  if not new or not old then
+    return false
+  end
+
+  local tnew, told = type(new), type(old)
+
+  if tnew == told then
+    if tnew == "string" then
+      return new == old
+    elseif tnew == "table" then
+      if new[1] and old[1] then
+        return (new[1] == old[1])
+      elseif new.type and old.type then
+        return (new.type == old.type)
+      elseif new.type and old[1] then
+        return (new.type == old[1])
+      elseif new[1] and old.type then
+        return (new[1] == old.type)
+      end
+    end
+  else
+    if tnew == "table" and told == "string" then
+      if new.type == old then
+        return true
+      elseif new[1] == old then
+        return true
+      end
+    elseif tnew == "string" and told == "table" then
+      return old.type == new or old[1] == new
+    end
+  end
+  -- return false
+end
+
+---Alter a given table, only support changing key definition
+---@param tname string
+---@param new table<string, SqlSchemaKeyDefinition>
+---@param old table<string, SqlSchemaKeyDefinition>
+M.auto_alter = function(tname, new, old, dry)
+  local tmpname = tname .. "_new"
+  local create = M.create(tmpname, new, true)
+  local drop = M.drop(tname)
+  local move = "INSERT INTO %s(%s) SELECT %s FROM %s"
+  local rename = ("ALTER TABLE %s RENAME TO %s;"):format(tmpname, tname)
+  local stmt = "PRAGMA foreign_keys=off; BEGIN TRANSACTION; %s COMMIT; PRAGMA foreign_keys=on"
+
+  local keys = { new = u.okeys(new), old = u.okeys(old) }
+  local idx = { new = {}, old = {} }
+  local len = { new = #keys.new, old = #keys.old }
+  local facts = { extra_key = len.new > len.old, drop_key = len.old > len.new }
+
+  a.auto_alter_should_have_equal_len(len.new, len.old, tname)
+
+  for _, varient in ipairs { "new", "old" } do
+    for k, v in pairs(keys[varient]) do
+      idx[varient][v] = k
+    end
+  end
+
+  for i, v in ipairs(keys.new) do
+    if idx.old[v] and idx.old[v] ~= i then
+      local tmp = keys.old[i]
+      keys.old[i] = v
+      keys.old[idx.old[v]] = tmp
+    end
+  end
+
+  local new_keys, old_keys = tconcat(keys.new, ", "), tconcat(keys.old, ", ")
+  local insert = move:format(tmpname, new_keys, old_keys, tname)
+
+  return not dry and stmt:format(tconcat({ create, insert, drop, rename }, "; ")) or insert
+end
+
+---Pre-process data insert to sql db.
 ---for now it's mainly used to for parsing lua tables and boolean values.
 ---It throws when a schema key is required and doesn't exists.
 ---@param rows tinserted row.

--- a/lua/sql/parser.lua
+++ b/lua/sql/parser.lua
@@ -425,40 +425,40 @@ M.drop = function(tbl)
   return "drop table " .. tbl
 end
 
-local same_type = function(new, old)
-  if not new or not old then
-    return false
-  end
+-- local same_type = function(new, old)
+--   if not new or not old then
+--     return false
+--   end
 
-  local tnew, told = type(new), type(old)
+--   local tnew, told = type(new), type(old)
 
-  if tnew == told then
-    if tnew == "string" then
-      return new == old
-    elseif tnew == "table" then
-      if new[1] and old[1] then
-        return (new[1] == old[1])
-      elseif new.type and old.type then
-        return (new.type == old.type)
-      elseif new.type and old[1] then
-        return (new.type == old[1])
-      elseif new[1] and old.type then
-        return (new[1] == old.type)
-      end
-    end
-  else
-    if tnew == "table" and told == "string" then
-      if new.type == old then
-        return true
-      elseif new[1] == old then
-        return true
-      end
-    elseif tnew == "string" and told == "table" then
-      return old.type == new or old[1] == new
-    end
-  end
-  -- return false
-end
+--   if tnew == told then
+--     if tnew == "string" then
+--       return new == old
+--     elseif tnew == "table" then
+--       if new[1] and old[1] then
+--         return (new[1] == old[1])
+--       elseif new.type and old.type then
+--         return (new.type == old.type)
+--       elseif new.type and old[1] then
+--         return (new.type == old[1])
+--       elseif new[1] and old.type then
+--         return (new[1] == old.type)
+--       end
+--     end
+--   else
+--     if tnew == "table" and told == "string" then
+--       if new.type == old then
+--         return true
+--       elseif new[1] == old then
+--         return true
+--       end
+--     elseif tnew == "string" and told == "table" then
+--       return old.type == new or old[1] == new
+--     end
+--   end
+--   -- return false
+-- end
 
 ---Alter a given table, only support changing key definition
 ---@param tname string
@@ -475,7 +475,7 @@ M.auto_alter = function(tname, new, old, dry)
   local keys = { new = u.okeys(new), old = u.okeys(old) }
   local idx = { new = {}, old = {} }
   local len = { new = #keys.new, old = #keys.old }
-  local facts = { extra_key = len.new > len.old, drop_key = len.old > len.new }
+  -- local facts = { extra_key = len.new > len.old, drop_key = len.old > len.new }
 
   a.auto_alter_should_have_equal_len(len.new, len.old, tname)
 

--- a/lua/sql/table.lua
+++ b/lua/sql/table.lua
@@ -96,7 +96,7 @@ end
 ---Create new sql table object
 ---@param db SQLDatabase
 ---@param name string: table name
----@param schema table: table schema
+---@param schema table<string, SqlSchemaKeyDefinition>
 ---@return SQLTable
 function tbl:new(db, name, schema)
   schema = schema or {}
@@ -112,7 +112,7 @@ end
 ---is called
 ---@param db SQLDatabase
 ---@param name string
----@param schema table
+---@param schema table<string, SqlSchemaKeyDefinition>
 ---@return SQLTableExt
 function tbl:extend(db, name, schema)
   if not schema and type(db) == "string" then
@@ -143,8 +143,8 @@ end
 ---Create or change table schema. If no {schema} is given,
 ---then it return current the used schema if it exists or empty table otherwise.
 ---On change schema it returns boolean indecting success.
----@param schema table: table schema definition
----@return table table | boolean
+---@param schema table<string, SqlSchemaKeyDefinition>
+---@return table<string, SqlSchemaKeyDefinition> | boolean
 ---@usage `projects:schema()` get project table schema.
 ---@usage `projects:schema({...})` mutate project table schema
 ---@todo do alter when updating the schema instead of droping it completely

--- a/lua/sql/table.lua
+++ b/lua/sql/table.lua
@@ -20,7 +20,7 @@ local check_for_auto_alter = function(o, valid_schema)
     return
   end
 
-  for k, def in pairs(o.tbl_schema) do
+  for _, def in pairs(o.tbl_schema) do
     if type(def) == "table" and def.reference then
       with_foregin_key = true
       break

--- a/lua/sql/table.lua
+++ b/lua/sql/table.lua
@@ -4,6 +4,8 @@
 ---@tag table.lua
 local u = require "sql.utils"
 local a = require "sql.assert"
+local fmt = string.format
+local P = require "sql.parser"
 local luv = require "luv"
 
 ---@class SQLTable @Main table class
@@ -11,26 +13,57 @@ local luv = require "luv"
 local tbl = {}
 tbl.__index = tbl
 
+local check_for_auto_alter = function(o, valid_schema)
+  if not valid_schema then
+    return
+  end
+  local get = fmt("select * from sqlite_master where name = '%s'", o.name)
+  local stmt = o.tbl_exists and o.db:eval(get) or nil
+
+  if type(stmt) == "table" then
+    local origin, parsed = stmt[1].sql, P.create(o.name, o.tbl_schema, true)
+
+    if origin ~= parsed then
+      local ok, cmd = pcall(P.auto_alter, o.name, o.tbl_schema, o.db:schema(o.name))
+      if not ok then
+        print(cmd)
+      else
+        o.db:execute(cmd)
+        o.db_schema = o.db:schema(o.name)
+      end
+    end
+  end
+end
+
+---Run tbl functions
+---@param func function: wrapped function to run
+---@param o SQLTable
+---@return any
 local run = function(func, o)
   a.should_have_db_object(o.db, o.name)
   local exec = function()
+    local valid_schema = o.tbl_schema and next(o.tbl_schema) ~= nil
+
+    --- Run once pre-init
     if o.tbl_exists == nil then
       o.tbl_exists = o.db:exists(o.name)
-      local stat = o.db.uri and luv.fs_stat(o.db.uri) or nil
-      o.mtime = stat and stat.mtime.sec or nil
-      local countsmt = "select count(*) from " .. o.name
-      o.has_content = o.tbl_exists and o.db:eval(countsmt)[1]["count(*)"] ~= 0 or 0
+      o.mtime = o.db.uri and (luv.fs_stat(o.db.uri) or { mtime = {} }).mtime.sec or nil
+      o.has_content = o.tbl_exists and o.db:eval(fmt("select count(*) from %s", o.name))[1]["count(*)"] ~= 0 or 0
+      check_for_auto_alter(o, valid_schema)
     end
 
-    if o.tbl_exists == false and o.tbl_schema and next(o.tbl_schema) ~= nil then
+    --- Run when tbl doesn't exists anymore
+    if o.tbl_exists == false and valid_schema then
       o.tbl_schema.ensure = u.if_nil(o.tbl_schema.ensure, true)
       o.db:create(o.name, o.tbl_schema)
     end
 
-    if type(o.db_schema) ~= "table" then
+    --- Run once when we don't have schema
+    if not o.db_schema then
       o.db_schema = o.db:schema(o.name)
     end
 
+    --- Run wrapped function
     return func()
   end
 
@@ -96,24 +129,19 @@ end
 ---@usage `projects:schema({...})` mutate project table schema
 ---@todo do alter when updating the schema instead of droping it completely
 function tbl:schema(schema)
-  local res
   return run(function()
     local exists = self.db:exists(self.name)
     if not schema then -- TODO: or table is empty
-      if exists then
-        self.tbl_schema = self.db:schema(self.name)
-        return self.tbl_schema
-      else
-        return {}
-      end
-    elseif not exists or schema.ensure then
-      res = self.db:create(self.name, schema)
-      self.tbl_exists = res
-      return res
-    elseif not schema.ensure then -- maybe better to use alter
-      res = exists and self.db:drop(self.name) or true
+      return exists and self.db:schema(self.name) or {}
+    end
+    if not exists or schema.ensure then
+      self.tbl_exists = self.db:create(self.name, schema)
+      return self.tbl_exists
+    end
+    if not schema.ensure then -- maybe better to use alter
+      local res = exists and self.db:drop(self.name) or true
       res = res and self.db:create(self.name, schema) or false
-      self.tbl_schema = self.db:schema(self.name)
+      self.tbl_schema = schema
       return res
     end
   end, self)

--- a/lua/sql/utils.lua
+++ b/lua/sql/utils.lua
@@ -51,6 +51,14 @@ M.is_list = function(t)
   end
 end
 
+M.okeys = function(t)
+  local r = {}
+  for k in M.opairs(t) do
+    r[#r + 1] = k
+  end
+  return r
+end
+
 M.opairs = (function()
   local __gen_order_index = function(t)
     local orderedIndex = {}

--- a/test/auto/parser_spec.lua
+++ b/test/auto/parser_spec.lua
@@ -117,7 +117,7 @@ describe("parse", function()
         done = { "int", "not", "null", "default", 0 },
       }
       local expected =
-        "create table todos(created int, desc text, done int not null default 0, id integer primary key, title text)"
+        "CREATE TABLE todos(created int, desc text, done int not null default 0, id integer primary key, title text)"
       local passed = p.create("todos", defs)
       eq(expected, passed, "should be identical")
     end)
@@ -129,7 +129,7 @@ describe("parse", function()
         age = "int",
         ensure = true,
       }
-      local expected = "create table if not exists people(age int, id integer primary key, name text)"
+      local expected = "CREATE TABLE if not exists people(age int, id integer primary key, name text)"
       local passed = p.create("people", defs)
       eq(expected, passed, "should be identical")
     end)
@@ -141,7 +141,7 @@ describe("parse", function()
         age = "int",
         ensure = true,
       }
-      local expected = "create table if not exists people(age int, id integer not null primary key, name text)"
+      local expected = "CREATE TABLE if not exists people(age int, id integer not null primary key, name text)"
       local passed = p.create("people", defs)
       eq(expected, passed, "should be identical")
     end)
@@ -152,7 +152,7 @@ describe("parse", function()
         name = { "text", required = true, unique = true },
       }
       local passed = p.create("people", defs)
-      local expected = "create table people(id integer not null primary key, name text unique not null)"
+      local expected = "CREATE TABLE people(id integer not null primary key, name text unique not null)"
       eq(expected, passed, "should be identical")
     end)
     it("key-pair: default value", function()
@@ -161,7 +161,7 @@ describe("parse", function()
         name = { "text", default = "unknown" },
       }
       local passed = p.create("people", defs)
-      local expected = "create table people(id integer not null primary key, name text default unknown)"
+      local expected = "CREATE TABLE people(id integer not null primary key, name text default unknown)"
       eq(expected, passed, "should be identical")
     end)
 
@@ -171,7 +171,7 @@ describe("parse", function()
         name = { type = "text" },
       }
       local passed = p.create("people", defs)
-      local expected = "create table people(id integer not null primary key, name text)"
+      local expected = "CREATE TABLE people(id integer not null primary key, name text)"
       eq(expected, passed, "should be identical")
     end)
 
@@ -182,7 +182,7 @@ describe("parse", function()
       }
       local passed = p.create("people", defs)
       local expected = {
-        "create table people(",
+        "CREATE TABLE people(",
         "id integer primary key, ",
         "name text default noname",
         ")",
@@ -201,7 +201,7 @@ describe("parse", function()
       }
       local passed = p.create("people", defs)
       local expected = {
-        "create table people(",
+        "CREATE TABLE people(",
         "id integer not null primary key, ",
         "job_id integer references jobs(id), ",
         "name text default unknown",
@@ -223,7 +223,7 @@ describe("parse", function()
       }
       local passed = p.create("people", defs)
       local expected = {
-        "create table people(",
+        "CREATE TABLE people(",
         "id integer not null primary key, ",
         "job_id integer references jobs(id) on update cascade, ",
         "name text default unknown",
@@ -246,7 +246,7 @@ describe("parse", function()
       }
       local passed = p.create("people", defs)
       local expected = {
-        "create table people(",
+        "CREATE TABLE people(",
         "id integer not null primary key, ",
         "job_id integer references jobs(id) on update cascade on delete set null, ",
         "name text default unknown",

--- a/test/auto/sql_spec.lua
+++ b/test/auto/sql_spec.lua
@@ -834,7 +834,7 @@ describe("sql", function()
       eq("/tmp/extend_db_new", manager.uri, "should set self.uri.")
       eq(true, manager.closed, "should construct without openning connection.")
       eq(nil, manager.conn, "should not set connection object.")
-      eq("boolean", type(manager.sqlite_opts.foreign_keys), "should have added opts to sqlite_opts.")
+      eq("boolean", type(manager.opts.foreign_keys), "should have added opts to sqlite_opts.")
     end)
 
     it("creates self.projects and self.todos", function()

--- a/test/auto/table_spec.lua
+++ b/test/auto/table_spec.lua
@@ -779,6 +779,37 @@ describe("table", function()
         },
       }
     end)
+
+    it("case: more than one rename with idetnical number of keys + default without required = true", function()
+      alter {
+        schema = {
+          before = { id = { type = "integer" }, name = { type = "text" }, age = { "integer" } },
+          after = {
+            id = { type = "integer", required = true },
+            some_name = { type = "text" },
+            since = {
+              type = "integer",
+              default = 20,
+            },
+          },
+        },
+        ----------------
+        data = {
+          before = {
+            { id = 1, name = "a", age = 5 },
+            { id = 2, name = "b", age = 6 },
+            { id = 3, name = "c", age = 7 },
+            { id = 4, name = "e" },
+          },
+          after = {
+            { id = 1, some_name = "a", since = 5 },
+            { id = 2, some_name = "b", since = 6 },
+            { id = 3, some_name = "c", since = 7 },
+            { id = 4, some_name = "e", since = 20 },
+          },
+        },
+      }
+    end)
     -- Failing
     --it("case: more than one rename with idetnical number of keys and additonal key", function()
     --  alter {


### PR DESCRIPTION
#### Purpose

I'm trying to support more then just key definition but it seems to be an impossible task.

I'm thinking of later supporting versioning schema and definition migration strategy interface. Should open an issue for that

TODOs

- [x] if default is present then replace null with default
- [x] add more tests, in particular changing a key definition to include a reference to another table
- [x] fix docgen remove of insert and schema docs
- [x] keep foreign_keys off when it's already off and none of the keys has reference key